### PR TITLE
Task-52641: Navigation bar of the analytics application not visible.

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -156,6 +156,9 @@
       <depends>
         <module>commonAnalyticsVueComponents</module>
       </depends>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
     </module>
   </portlet>
 

--- a/analytics-webapps/src/main/webapp/WEB-INF/jsp/breadcrumb.jsp
+++ b/analytics-webapps/src/main/webapp/WEB-INF/jsp/breadcrumb.jsp
@@ -31,6 +31,6 @@
     <v-cacheable-dom-app cache-id="<%=cacheId%>"></v-cacheable-dom-app>
     <script type="text/javascript">
             require(['PORTLET/analytics/AnalyticsDashboardBreadcrumb'], app => app.init('<%=cacheId%>'));
-        </script>
+    </script>                                                                                   
   </div>
 </div>

--- a/analytics-webapps/src/main/webapp/vue-app/breadcrumb-portlet/main.js
+++ b/analytics-webapps/src/main/webapp/vue-app/breadcrumb-portlet/main.js
@@ -29,17 +29,17 @@ const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale
 
 export function init(cacheId) {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
-    const appElement = document.createElement('div');
-    appElement.id = appId;
 
     // init Vue app when locale ressources are ready
-    new Vue({
+ 
+    Vue.createApp({
       mounted() {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
       },
       template: `<analytics-breadcrumb v-cacheable="{cacheId: '${cacheId}'}" id="${appId}" />`,
       vuetify,
       i18n
-    }).$mount(appElement);
+     
+    }, `#${appId}`, 'analytics');
   });
 }


### PR DESCRIPTION
Problem: Before this fix, when refreshing analytics page sometimes analytics Dashboard Breadcrumb is not displayed. So the problem was in the way of using the directive v-cacheable and that is why many problems founded when the browser, try to interpret this component so sometimes has unexpected behavior.

Fix: Use this directive (v-cacheable) in a good way by removing div element also by changing the instantiation method of the app view by replacing new view with the createapp method of views 3 in fact it is more performance then we mounted this application directly by the appId and finally we added the dependency "commonVueComponents" to be able to use the methode createapp.