### PR TITLE
TASK-55655 Fix Web Socket initialization

### DIFF
--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -41,7 +41,7 @@ function() {
         self_.connected = handshake && handshake.successful;
       });
       const loc = window.location;
-      cCometd.init({
+      cCometd.configure({
         url: `${loc.protocol}//${loc.hostname}${(loc.port && ':') || ''}${loc.port || ''}/${this.settings.cometdContext}/cometd`,
         exoId: eXo.env.portal.userName,
         exoToken: this.settings.cometdToken,


### PR DESCRIPTION
Prior to this change, the WebSocket initialization made by method `cCometd.init` doesn't transmit `exoId` and `exoToken` to handshake correctly with server side. Thus, the method `cCometd.configure` has to be used to handshake correctly WebSocket channel.