### PR TITLE
Task-52019: Display mobile analytics data

### DIFF
--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -296,8 +296,7 @@ function() {
           window.setTimeout(sendMobileStatistics,1000);
         }
       });
-    }
-    if (eXo.env.portal.requestStartTime) {
+    } else {
       eXo.env.portal.loadingAppsStartTime = {};
       const fullyLoadedCallbackIdle = 1000;
       const isMobile = navigator.userAgentData && navigator.userAgentData.mobile || (navigator.userAgent && /mobi/i.test(navigator.userAgent.toLowerCase())) || false;

--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -379,8 +379,6 @@ function() {
                 pageUri: eXo.env.portal.selectedNodeUri,
                 applicationNames: eXo.env.portal.applicationNames,
                 isMobile,
-                deviceType: deviceType,
-                connectedWith: connectedWith,
               },
             });
           }, 500);

--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -268,12 +268,35 @@ function() {
       return isExoApp(userAgentLowerCase) && /android/.test(userAgentLowerCase); 
   }
   require(['SHARED/vue'], () => {
+    const isMobile = navigator.userAgentData && navigator.userAgentData.mobile || (navigator.userAgent && /mobi/i.test(navigator.userAgent.toLowerCase())) || false;
+    const deviceType = checkDeviceType(navigator.userAgent.toLowerCase());
+    const connectedWith = checkconnectedWith(navigator.userAgent.toLowerCase());
+    function sendMobileStatistics() {
+        api.sendMessage({
+          name: 'pageUIDisplay',
+          operation: 'pageFullUIDisplay',
+          userName: eXo.env.portal.userName,
+          spaceId: eXo.env.portal.spaceId,
+          parameters: {
+            portalName: eXo.env.portal.portalName,
+            portalUri: eXo.env.server.portalBaseURL,
+            pageUri: window.location.pathname,
+            pageTitle: eXo.env.portal.pageTitle,
+            pageUri: eXo.env.portal.selectedNodeUri,
+            applicationNames: eXo.env.portal.applicationNames,
+            isMobile,
+            deviceType: deviceType,
+            connectedWith: connectedWith,
+          },
+        });  
+    }
+    document.addEventListener('vue-app-loading-end',()=>{
+      window.setTimeout(sendMobileStatistics,500);
+    });
     if (eXo.env.portal.requestStartTime) {
       eXo.env.portal.loadingAppsStartTime = {};
       const fullyLoadedCallbackIdle = 1000;
       const isMobile = navigator.userAgentData && navigator.userAgentData.mobile || (navigator.userAgent && /mobi/i.test(navigator.userAgent.toLowerCase())) || false;
-      const deviceType = checkDeviceType(navigator.userAgent.toLowerCase());
-      const connectedWith = checkconnectedWith(navigator.userAgent.toLowerCase());
       function pageFullyLoadedCallback() {
         if (document.readyState === 'complete'
             && !eXo.env.portal.loadingAppsFinished
@@ -304,8 +327,6 @@ function() {
               pageUri: eXo.env.portal.selectedNodeUri,
               applicationNames: eXo.env.portal.applicationNames,
               isMobile,
-              deviceType: deviceType,
-              connectedWith: connectedWith,
             },
           });
         }
@@ -422,8 +443,6 @@ function() {
                 pageUri: eXo.env.portal.selectedNodeUri,
                 applicationName: appName,
                 isMobile,
-                deviceType: deviceType,
-                connectedWith: connectedWith,
                 startLoadingTime: startLoadingTime,
                 endLoadingTime: endLoadingTime,
               },

--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -290,9 +290,13 @@ function() {
           },
         });  
     }
-    document.addEventListener('vue-app-loading-end',()=>{
-      window.setTimeout(sendMobileStatistics,500);
-    });
+    if(!eXo.env.portal.requestStartTime){
+      document.addEventListener('readystatechange',(event)=>{
+        if (event.target.readyState === 'complete') {
+          window.setTimeout(sendMobileStatistics,1000);
+        }
+      });
+    }
     if (eXo.env.portal.requestStartTime) {
       eXo.env.portal.loadingAppsStartTime = {};
       const fullyLoadedCallbackIdle = 1000;
@@ -327,6 +331,8 @@ function() {
               pageUri: eXo.env.portal.selectedNodeUri,
               applicationNames: eXo.env.portal.applicationNames,
               isMobile,
+              deviceType: deviceType,
+              connectedWith: connectedWith,
             },
           });
         }


### PR DESCRIPTION
ISSUE: mobile analytics were being sent only if the FrontEndperformanceTracking feature was active or in a dev environment 
FIX: sending the data each time the vue-app-loading-end event occurs, the data being sent is reformatted to be as minimal as possible to conserve front end performance 
