### PR TITLE
task-52026: removed unnecessary check on the safari string

### DIFF
--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -262,7 +262,7 @@ function() {
     return /exo/.test(userAgentLowerCase); 
   }
   function isIosApp(userAgentLowerCase){
-    return  isExoApp(userAgentLowerCase) && /iphone|ipad|ipad/.test(userAgentLowerCase); 
+    return  isExoApp(userAgentLowerCase) && /iphone|ipad/.test(userAgentLowerCase); 
   }
   function isAndroidApp(userAgentLowerCase){
       return isExoApp(userAgentLowerCase) && /android/.test(userAgentLowerCase); 

--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -262,7 +262,7 @@ function() {
     return /exo/.test(userAgentLowerCase); 
   }
   function isIosApp(userAgentLowerCase){
-    return  isExoApp(userAgentLowerCase) && /iphone|ipad|ipad/.test(userAgentLowerCase) && !/safari/.test(userAgentLowerCase); 
+    return  isExoApp(userAgentLowerCase) && /iphone|ipad|ipad/.test(userAgentLowerCase); 
   }
   function isAndroidApp(userAgentLowerCase){
       return isExoApp(userAgentLowerCase) && /android/.test(userAgentLowerCase); 


### PR DESCRIPTION
ISSUE: the user agent for the ios application have a "safari" string in it which will make the isIosApp return false
FIX removed unnecessary test for the existence of safari string
to detect the ios application it's sufficient to test for the "exo" string and the "iphone" or  the "ipad"  string in the user agent