### PR TITLE
Task-57262: Filter space in analytics page does not display all spaces

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
@@ -127,7 +127,7 @@ export default {
     columnsData: {},
     searchOptions: {
       currentUser: '',
-      filterType: '',
+      filterType: 'all',
     },
   }),
   computed: {

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
@@ -127,6 +127,7 @@ export default {
     columnsData: {},
     searchOptions: {
       currentUser: '',
+      filterType: '',
     },
   }),
   computed: {


### PR DESCRIPTION
Prior to this fix, when i filter space in analytics , except spaces that belongs member is display.
After this fix, we avoid displaying all spaces when filtering in analytics.