### PR TITLE
Fix sonar configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <org.exoplatform.platform-ui.version>6.4.x-SNAPSHOT</org.exoplatform.platform-ui.version>
 
     <!-- Sonar properties -->
-    <sonar.organization>exoplatform</sonar.organization>
+    <sonar.organization>meeds-io</sonar.organization>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
As analytics module was moved from exoplatform organization to meeds-io, we need to update the property sonar.organization