### PR TITLE
fix: Fix Analytics ES JSON response parsing - Meeds-io/meeds#323 - MEED-716

### DIFF
--- a/analytics-services/src/main/java/org/exoplatform/analytics/es/service/ESAnalyticsService.java
+++ b/analytics-services/src/main/java/org/exoplatform/analytics/es/service/ESAnalyticsService.java
@@ -892,7 +892,7 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
                                       boolean isValue) throws JSONException {
     Object value;
     if (bucket.has(AGGREGATION_RESULT_VALUE_PARAM)) {
-      value = bucket.getJSONObject(AGGREGATION_RESULT_VALUE_PARAM).getString("value");
+      value = bucket.getJSONObject(AGGREGATION_RESULT_VALUE_PARAM).get("value");
     } else if (bucket.has(AGGREGATION_RESULT_PARAM)) {
       JSONObject subAggregationResult = bucket.getJSONObject(AGGREGATION_RESULT_PARAM);
       List<String> values = new ArrayList<>();
@@ -905,21 +905,21 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
       }
       value = values;
     } else if (bucket.has("value")) {
-      value = bucket.getString("value");
+      value = bucket.get("value");
     } else {
       value = null;
     }
     if (isValue) {
       if (isCurrent) {
-        itemValue.setValue(value);
+        itemValue.setValue(toString(value));
       } else {
-        itemValue.setPreviousValue(value);
+        itemValue.setPreviousValue(toString(value));
       }
     } else {
       if (isCurrent) {
-        itemValue.setThreshold(value);
+        itemValue.setThreshold(toString(value));
       } else {
-        itemValue.setPreviousThreshold(value);
+        itemValue.setPreviousThreshold(toString(value));
       }
     }
   }
@@ -939,7 +939,7 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
     percentageChartValue.setDataCount(hitsResult.getJSONObject("total").getLong("value"));
 
     if (aggregations.has(AGGREGATION_BUCKETS_VALUE_PARAM)) {
-      String value = aggregations.getJSONObject(AGGREGATION_BUCKETS_VALUE_PARAM).getString("value");
+      String value = toString(aggregations.getJSONObject(AGGREGATION_BUCKETS_VALUE_PARAM).get("value"));
       double valueDouble = StringUtils.isBlank(value) || StringUtils.equals("null", value) ? 0d : Double.parseDouble(value);
       if (currentPeriod != null) {
         percentageChartValue.setCurrentPeriodValue(valueDouble);
@@ -954,11 +954,11 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
           JSONObject bucket = buckets.getJSONObject(i);
           Long timestamp = bucket.getLong("key");
           if (bucket.has(AGGREGATION_BUCKETS_VALUE_PARAM)) {
-            String value = bucket.getJSONObject(AGGREGATION_BUCKETS_VALUE_PARAM).getString("value");
+            String value = toString(bucket.getJSONObject(AGGREGATION_BUCKETS_VALUE_PARAM).get("value"));
             values.put(timestamp,
                        StringUtils.isBlank(value) || StringUtils.equals("null", value) ? 0d : Double.parseDouble(value));
           } else if (bucket.has(AGGREGATION_RESULT_VALUE_PARAM)) {
-            String value = bucket.getJSONObject(AGGREGATION_RESULT_VALUE_PARAM).getString("value");
+            String value = toString(bucket.getJSONObject(AGGREGATION_RESULT_VALUE_PARAM).get("value"));
             values.put(timestamp,
                        StringUtils.isBlank(value) || StringUtils.equals("null", value) ? 0d : Double.parseDouble(value));
           } else {
@@ -1139,7 +1139,7 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
       Iterator<?> remainingKeys = statisticDataJsonObject.keys();
       while (remainingKeys.hasNext()) {
         String key = (String) remainingKeys.next();
-        statisticData.getParameters().put(key, statisticDataJsonObject.getString(key));
+        statisticData.getParameters().put(key, toString(statisticDataJsonObject.get(key)));
       }
 
       results.add(statisticData);
@@ -1164,7 +1164,7 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
       Iterator keys = jsonObject.keys();
       while (keys.hasNext()) {
         String key = keys.next().toString();
-        String fieldMappingString = jsonObject.getString(key);
+        String fieldMappingString = toString(jsonObject.get(key));
         StatisticFieldMapping fieldMapping = fromJsonString(fieldMappingString, StatisticFieldMapping.class);
         esMappings.put(key, fieldMapping);
       }
@@ -1206,7 +1206,11 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
   }
 
   private String getResultKeyAsString(JSONObject bucketResult) throws JSONException {
-    return bucketResult.has("key_as_string") ? bucketResult.getString("key_as_string") : String.valueOf(bucketResult.get("key"));
+    return bucketResult.has("key_as_string") ? bucketResult.getString("key_as_string") : toString(bucketResult.get("key"));
+  }
+
+  private String toString(Object value) {
+    return Objects.toString(value, null);
   }
 
 }


### PR DESCRIPTION
Prior to this change, an error is raised when ES response is returned using percentage `AnalyticsFilter`.
This error is due to an update of JSON library that is more strict and raises an exception when the value isn't an instance of String. This change will allow to parse the returned value in String even if it's of type int or double to consider null and not supported values.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
