### PR TITLE
fix: Fix generated operation without name when uploading file - EXO-56830 - Meeds-io/meeds#372

### DIFF
--- a/analytics-api/src/main/java/org/exoplatform/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/org/exoplatform/analytics/utils/AnalyticsUtils.java
@@ -304,7 +304,7 @@ public class AnalyticsUtils {
 
   @ExoTransactional
   public static final void addStatisticData(StatisticData statisticData) {
-    if (statisticData == null) {
+    if (statisticData == null || statisticData.getOperation() == null) {
       return;
     }
     if (statisticData.getTimestamp() <= 0) {


### PR DESCRIPTION
Prior to this change when uploading a new file, an analytics operation without name is generated and displayed in addition to `file Created` and `Document uploaded` analytics operations when filtering data by userId on activities chart of analytics application. After this PR, we will modify the `addStatisticData` method by not allowing to save statistic data if operation name is null. 