### PR TITLE
fix : Fix title of analytics chart are not translated - EXO-58757 - Meeds-io/meeds#412

### DIFF
--- a/analytics-webapps/src/main/resources/locale/portlet/Analytics_en.properties
+++ b/analytics-webapps/src/main/resources/locale/portlet/Analytics_en.properties
@@ -247,6 +247,7 @@ analytics.pageDisplay=Page display
 analytics.login=Login
 analytics.usersCount=Users count
 analytics.logout=Logout
+analytics.distinctLogins=Distinct logins
 analytics.spaceBannerEdited=Space banner edited
 analytics.spaceCreated=Space created
 analytics.click=Click

--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/portal/portal/global/pages.xml
@@ -56,7 +56,7 @@
                       "valueString": "login"
                     }
                   ],
-                  "title": "Distinct logins",
+                  "title": "analytics.distinctLogins",
                   "aggregations": [
                     {
                       "field": "timestamp",
@@ -100,7 +100,7 @@
               <preference>
                 <name>settings</name>
                 <value>{
-                 "title":"Users count",
+                 "title":"analytics.usersCount",
                  "chartType":"line",
                  "multipleChartsField":"countType.keyword",
                  "filters":[
@@ -288,7 +288,7 @@
                 <name>settings</name>
                 <value>{
                   "offset": 0,
-                  "title": "Spaces count",
+                  "title": "analytics.spacesCount",
                   "aggregations": [
                     {
                       "field": "timestamp",
@@ -345,7 +345,7 @@
                 <name>settings</name>
                 <value>{
                   "offset": 0,
-                  "title": "Activities",
+                  "title": "analytics.activitiesCount",
                   "lang": null,
                   "aggregations": [
                     {


### PR DESCRIPTION
Prior to this change default analytics chart titles in analytics page are not translated when we change the platform language. After this change, all default analytics titles in analytics page will be translated.