### PR TITLE
fix : Deleted space message displayed instead of space name in the content analytics page - Meeds-io/meeds#903 - EXO-63797

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellSpaceValue.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellSpaceValue.vue
@@ -63,6 +63,7 @@ export default {
     space: null,
   }),
   created() {
+    this.value = JSON.parse(this.value);
     if (this.value && this.value.prettyName) {
       this.space = this.value;
       this.loading = false;


### PR DESCRIPTION
before to this change in analytic content analytics page the message 'deleted space ' was displayed instead of the space name , the issue was that the props property value used to find the space by id isn't being parsed .
This change is going to parse the props property value to find correctly the space . 