### PR TITLE
feat: No access to items that are overflow - MEED-2728-Meeds-io/MIPs#81

### DIFF
--- a/analytics-webapps/src/main/webapp/skin/less/analytics.less
+++ b/analytics-webapps/src/main/webapp/skin/less/analytics.less
@@ -101,7 +101,7 @@
   box-sizing: content-box;
 }
 .VuetifyApp .analytics-application {
-  background: transparent !important;
+  background: white !important;
   max-width: fit-content;
   margin: auto;
   min-width: 100%;

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
@@ -17,7 +17,7 @@
 <template>
   <v-app 
     :id="appId"
-    class="analytics-application card-border-radius overflow-hidden"
+    class="analytics-application card-border-radius"
     flat>
     <template v-if="canEdit">
       <analytics-chart-setting
@@ -37,7 +37,7 @@
         :retrieve-samples-url="retrieveChartSamplesUrl"
         class="mt-0" />
     </template>
-    <v-card class="ma-auto analytics-chart-parent white" flat>
+    <v-card class="ma-auto analytics-chart-parent transparent" flat>
       <div class="d-flex pa-3 analytics-chart-header" flat>
         <v-toolbar-title class="d-flex">
           <v-tooltip bottom>

--- a/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
@@ -17,7 +17,7 @@
 <template>
   <v-app 
     :id="appId"
-    class="analytics-application card-border-radius overflow-hidden"
+    class="analytics-application card-border-radius"
     flat>
     <template v-if="canEdit">
       <analytics-chart-setting
@@ -27,7 +27,7 @@
         class="mt-0"
         @save="saveSettings" />
     </template>
-    <v-card class="d-flex flex-column ma-auto analytics-chart-percentage analytics-chart-parent white" flat>
+    <v-card class="d-flex flex-column ma-auto analytics-chart-percentage analytics-chart-parent transparent" flat>
       <div class="d-flex pa-3 analytics-chart-header" flat>
         <v-toolbar-title class="d-flex">
           <v-tooltip bottom>

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
@@ -17,9 +17,9 @@
 <template>
   <v-app
     :id="appId"
-    class="analytics-application card-border-radius overflow-hidden"
+    class="analytics-application white card-border-radius"
     flat>
-    <div class="d-flex px-3 pb-2 pt-1 white analytics-table-header" flat>
+    <div class="d-flex px-3 pb-2 pt-1 analytics-table-header" flat>
       <analytics-select-period
         v-model="selectedPeriod"
         hide-time

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -26,7 +26,7 @@
     hide-default-footer
     disable-pagination
     disable-filtering
-    class="analytics-table border-box-sizing px-2">
+    class="analytics-table border-box-sizing px-2 card-border-radius">
     <template
       v-for="header in headers"
       #[`item.${header.value}`]="{item}">


### PR DESCRIPTION
Prior to this change, calendar in the analytics page is not well displayed due to to overflow-hidden class added to enable branding border radius.
This PR allows  to fix the display of all calendars in the analytics app.