### PR TITLE
feat: Delete AppCenter Mandatory Flag - MEED-3034 - Meeds-io/meeds#1371

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/app-center-configuration.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/app-center-configuration.xml
@@ -60,9 +60,6 @@
             <field name="active">
               <boolean>true</boolean>
             </field>
-            <field name="isMandatory">
-              <boolean>true</boolean>
-            </field>
             <field name="isMobile">
               <boolean>true</boolean>
             </field>


### PR DESCRIPTION
This change will delete mandatory flag from AppCenter application to let users choose it when needed instead of adding it systematically.