### PR TITLE
fix: Avoid NPE when Analytics ES Mapping Field is not found - MEED-3194 - Meeds-io/MIPs#106

### DIFF
--- a/analytics-services/src/main/java/org/exoplatform/analytics/es/service/ESAnalyticsService.java
+++ b/analytics-services/src/main/java/org/exoplatform/analytics/es/service/ESAnalyticsService.java
@@ -169,6 +169,9 @@ public class ESAnalyticsService implements AnalyticsService, Startable {
         String[] fieldNames = JSONObject.getNames(mappingObject);
         for (String fieldName : fieldNames) {
           JSONObject esField = mappingObject.getJSONObject(fieldName);
+          if (esField == null || !esField.has("type")) {
+            continue;
+          }
           String fieldType = esField.getString("type");
           JSONObject keywordField = getJSONObject(esField, 0, "fields", "keyword");
           StatisticFieldMapping esFieldMapping = new StatisticFieldMapping(fieldName, fieldType, keywordField != null);


### PR DESCRIPTION
Prior to this change, when an ES field mapping isn't recognized, an NPE error prevent reading the other fields mapping. This change will check on nullability of returned field type from ES JSON response.

- Resolves Meeds-io/MIPs#58