### PR TITLE
feat: Allow to load AnalyticsExtension modules from AnalyticsTablePortletGroup load group - EXO-69984 - Meeds-io/meeds#1717

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/main.js
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/main.js
@@ -72,5 +72,5 @@ export function init(dataId) {
         vuetify,
         i18n
       }).$mount(`#${dataId}`);
-    });
+    }).finally(() => Vue.prototype.$utils.includeExtensions('AnalyticsTableExtension'));
 }


### PR DESCRIPTION
Prior to this change, AnalyticsTablePortlet define its own load-group AnalyticsTablePortletGroup, we need to add Vue.prototype.$utils.includeExtensions('AnalyticsExtension')); to its main.js in order to allow loading external extensions of the same load-group. 