### PR TITLE
fix: Fix Usage os Analytics in Layout Editor Page - MEED-6266 - Meeds-io/meeds#1917

### DIFF
--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -30,6 +30,9 @@ function() {
       }
     },
     initCometd : function() {
+      if (!this.settings?.cometdToken) {
+        return;
+      }
       const self_ = this;
       cCometd.addListener('/meta/connect', function (message) {
         self_.connected = !cCometd.isDisconnected();
@@ -344,7 +347,7 @@ function() {
       }
     },
     sendMessage : function(statisticMessage) {
-      if (statisticMessage) {
+      if (statisticMessage && this.settings?.cometdToken) {
         statisticMessage.token = this.settings.cometdToken;
         cCometd.publish(this.settings.cometdChannel, JSON.stringify(statisticMessage));
       }


### PR DESCRIPTION
This change will ensure to not send Statistics messages when using Layout editor while the settings isn't initialized yet in order to avoid exceptions logging in console.