### PR TITLE
fix: Fix Statistics Collection initialization - MEED-6885 - Meeds-io/MIPs#133

### DIFF
--- a/analytics-webapps/src/main/java/org/exoplatform/addon/analytics/portlet/StatisticDataCollectionPortlet.java
+++ b/analytics-webapps/src/main/java/org/exoplatform/addon/analytics/portlet/StatisticDataCollectionPortlet.java
@@ -47,9 +47,6 @@ public class StatisticDataCollectionPortlet extends GenericPortlet {
   @Override
   protected void doView(RenderRequest request, RenderResponse response) throws IOException, PortletException {
     if (StringUtils.isNotBlank(request.getRemoteUser())) {
-      UserSettings userSettings = getAnalyticsWebSocketService().getUserSettings(request.getRemoteUser());
-      request.setAttribute("userSettings", AnalyticsUtils.toJsonString(userSettings));
-
       List<StatisticWatcher> uiWatchers = getAnalyticsService().getUIWatchers();
       request.setAttribute("uiWatchers", AnalyticsUtils.toJsonString(uiWatchers));
 

--- a/analytics-webapps/src/main/webapp/WEB-INF/jsp/analytics-rate.jsp
+++ b/analytics-webapps/src/main/webapp/WEB-INF/jsp/analytics-rate.jsp
@@ -50,6 +50,6 @@
     data-save-settings-url="<%=saveSettingsURL%>">
   </div>
   <script type="text/javascript">
-    require(['PORTLET/analytics/AnalyticsRatePortlet'], app => app.init('analytics-rate-<%= generatedId %>'));
+    window.require(['PORTLET/analytics/AnalyticsRatePortlet'], app => app.init('analytics-rate-<%= generatedId %>'));
   </script>
 </div>

--- a/analytics-webapps/src/main/webapp/WEB-INF/jsp/analytics-table.jsp
+++ b/analytics-webapps/src/main/webapp/WEB-INF/jsp/analytics-table.jsp
@@ -50,6 +50,6 @@
          data-save-settings-url="<%=saveSettingsURL%>">
     </div>
     <script type="text/javascript">
-        require(['PORTLET/analytics/AnalyticsTablePortlet'], app => app.init('analytics-<%= generatedId %>'));
+      window.require(['PORTLET/analytics/AnalyticsTablePortlet'], app => app.init('analytics-<%= generatedId %>'));
     </script>
 </div>

--- a/analytics-webapps/src/main/webapp/WEB-INF/jsp/analytics.jsp
+++ b/analytics-webapps/src/main/webapp/WEB-INF/jsp/analytics.jsp
@@ -54,6 +54,6 @@
     data-save-settings-url="<%=saveSettingsURL%>">
   </div>
   <script type="text/javascript">
-    require(['PORTLET/analytics/AnalyticsPortlet'], app => app.init('analytics-<%= generatedId %>'));
+    window.require(['PORTLET/analytics/AnalyticsPortlet'], app => app.init('analytics-<%= generatedId %>'));
   </script>
 </div>

--- a/analytics-webapps/src/main/webapp/WEB-INF/jsp/breadcrumb.jsp
+++ b/analytics-webapps/src/main/webapp/WEB-INF/jsp/breadcrumb.jsp
@@ -30,7 +30,7 @@
     id="analyticsDashboardBreadcrumb">
     <v-cacheable-dom-app cache-id="<%=cacheId%>"></v-cacheable-dom-app>
     <script type="text/javascript">
-            require(['PORTLET/analytics/AnalyticsDashboardBreadcrumb'], app => app.init('<%=cacheId%>'));
+      window.require(['PORTLET/analytics/AnalyticsDashboardBreadcrumb'], app => app.init('<%=cacheId%>'));
     </script>                                                                                   
   </div>
 </div>

--- a/analytics-webapps/src/main/webapp/WEB-INF/jsp/statistics-collection.jsp
+++ b/analytics-webapps/src/main/webapp/WEB-INF/jsp/statistics-collection.jsp
@@ -16,11 +16,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 %>
-<script>
-  require(['PORTLET/analytics/StatisticsCollection'], (stats) => {
-    stats.init.call(stats,
-      <%=request.getAttribute("userSettings")%>,
-      <%=request.getAttribute("uiWatchers")%>
-    );
+<script type="text/javascript">
+  window.require(['PORTLET/analytics/StatisticsCollection'], (stats) => {
+    stats.init.call(stats, <%=request.getAttribute("uiWatchers")%>);
   });
 </script>

--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -16,23 +16,23 @@
  */
 function() {
   const api = {
-    init : function (settings, watchers) {
-      if (settings && watchers && !this.watchers) {
-        this.watchers = watchers;
-        this.settings = settings;
-
+    init : function (watchers) {
+      if (!this.settings) {
+        this.settings = {
+          cometdContext: eXo.env.portal.cometdContext,
+          cometdToken: eXo.env.portal.cometdToken,
+          cometdChannel: '/service/analytics',
+        };
         this.initCometd();
+      }
+
+      if (watchers && !this.watchers?.length) {
+        this.watchers = watchers;
         this.installWatchers();
-        const _self = this;
-        document.addEventListener("analytics-install-watchers", function() {
-          _self.installWatchers();
-        });
+        document.addEventListener("analytics-install-watchers", () => this.installWatchers());
       }
     },
     initCometd : function() {
-      if (!this.settings?.cometdToken) {
-        return;
-      }
       const self_ = this;
       cCometd.addListener('/meta/connect', function (message) {
         self_.connected = !cCometd.isDisconnected();
@@ -347,7 +347,7 @@ function() {
       }
     },
     sendMessage : function(statisticMessage) {
-      if (statisticMessage && this.settings?.cometdToken) {
+      if (statisticMessage) {
         statisticMessage.token = this.settings.cometdToken;
         cCometd.publish(this.settings.cometdChannel, JSON.stringify(statisticMessage));
       }
@@ -595,6 +595,6 @@ function() {
       });
     }
   });
-
+  api.init.call(api, []);
   return api;
 }();


### PR DESCRIPTION
Prior to this change, the Statistics collection portlet isn't initialized properly due to missing portlet instanciation in shared layout. This change ensures to have statistics initialized all time even when the settings aren't added by portlet.