### PR TITLE
feat: Allow to purge automatically Analytics Indices - MEED-6999 - Meeds-io/meeds#2097

### DIFF
--- a/analytics-services/src/main/resources/conf/portal/configuration.xml
+++ b/analytics-services/src/main/resources/conf/portal/configuration.xml
@@ -42,6 +42,10 @@
         <value>${exo.es.analytics.index.per.days:7}</value>
       </value-param>
       <value-param>
+        <name>analytics.es.index.maxCount</name>
+        <value>${analytics.es.index.maxCount:500}</value>
+      </value-param>
+      <value-param>
         <name>index.template.file.path</name>
         <value>${exo.es.analytics.index.template.path:jar:/analytics-es-template.json}</value>
       </value-param>


### PR DESCRIPTION
This change will allow to purge Analytics indices by specifying the maximum number of indices to keep. A parameter has been added `analytics.es.index.maxCount` to allow specifying it with default value to `500`.
This will include a fix as well on index creation periodicity (`exo.es.analytics.index.per.days` param with default to 7 days) which was creating an index daily independently from parameter value.