### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -172,6 +172,10 @@
   <portlet>
     <portlet-name>StatisticsCollection</portlet-name>
     <portlet-class>io.meeds.analytics.portlet.StatisticDataCollectionPortlet</portlet-class>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-style</value>
+    </init-param>
     <expiration-cache>-1</expiration-cache>
     <supports>
       <mime-type>text/html</mime-type>

--- a/analytics-webapps/src/main/webapp/skin/less/analytics.less
+++ b/analytics-webapps/src/main/webapp/skin/less/analytics.less
@@ -102,7 +102,6 @@
   box-sizing: content-box;
 }
 .VuetifyApp .analytics-application {
-  background: white !important;
   max-width: fit-content;
   margin: auto;
   min-width: 100%;

--- a/analytics-webapps/src/main/webapp/vue-app/breadcrumb-portlet/components/AnalyticsDashboardBreadcrumb.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/breadcrumb-portlet/components/AnalyticsDashboardBreadcrumb.vue
@@ -20,7 +20,7 @@
 <template>
   <v-app>
     <v-card
-      class="card-border-radius app-background-color"
+      class="application-body"
       flat>
       <v-list>
         <v-list-item>

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/AnalyticsApplication.vue
@@ -20,7 +20,7 @@
 <template>
   <v-app 
     :id="appId"
-    class="analytics-application card-border-radius app-background-color"
+    class="analytics-application application-body"
     flat>
     <template v-if="canEdit">
       <analytics-chart-setting

--- a/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
@@ -20,7 +20,7 @@
 <template>
   <v-app 
     :id="appId"
-    class="analytics-application card-border-radius app-background-color"
+    class="analytics-application application-body"
     flat>
     <template v-if="canEdit">
       <analytics-chart-setting

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/AnalyticsTableApplication.vue
@@ -20,7 +20,7 @@
 <template>
   <v-app
     :id="appId"
-    class="analytics-application card-border-radius app-background-color"
+    class="analytics-application application-body"
     flat>
     <div class="d-flex px-3 pb-2 pt-1 analytics-table-header" flat>
       <analytics-select-period

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -29,7 +29,7 @@
     hide-default-footer
     disable-pagination
     disable-filtering
-    class="analytics-table border-box-sizing px-2 card-border-radius">
+    class="analytics-table border-box-sizing px-2 application-body">
     <template
       v-for="header in headers"
       #[`item.${header.value}`]="{item}">


### PR DESCRIPTION
This change will apply **application-body** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.