### PR TITLE
fix: Fix PWA mode detection - MEED-7346 - Meeds-io/meeds#2326

### DIFF
--- a/analytics-webapps/src/main/webapp/js/statistic-collection.js
+++ b/analytics-webapps/src/main/webapp/js/statistic-collection.js
@@ -425,7 +425,7 @@ function() {
   }
   require(['SHARED/vue'], () => {
     const isMobile = navigator.userAgentData && navigator.userAgentData.mobile || (navigator.userAgent && /mobi/i.test(navigator.userAgent.toLowerCase())) || false;
-    const isPwa = !!window?.matchMedia('(display-mode: standalone)')?.matches;
+    const isPwa = !!(window?.matchMedia('(display-mode: standalone)')?.matches || window?.matchMedia('(display-mode: tabbed)')?.matches);
     const deviceType = checkDeviceType(navigator.userAgent.toLowerCase());
     const connectedWith = checkconnectedWith(navigator.userAgent.toLowerCase());
     eXo.env.portal.loadingAppsStartTime = {};


### PR DESCRIPTION
Prior to this change, when the PWA application is installed in tabbed mode, the analytics isPWA flag doezn't use the correct value. This change will include the display-mode 'tabbed' to detect whether the displayed page is in PWA application or in browser app.