### PR TITLE
fix: Delete JCabi Plugin Definition - Meeds-io/meeds#2417

### DIFF
--- a/analytics-listeners/pom.xml
+++ b/analytics-listeners/pom.xml
@@ -52,13 +52,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  <build>
-    <finalName>analytics-listeners</finalName>
-    <plugins>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/analytics-services/pom.xml
+++ b/analytics-services/pom.xml
@@ -50,13 +50,4 @@
       <type>test-jar</type>
     </dependency>
   </dependencies>
-  <build>
-    <finalName>analytics-services</finalName>
-    <plugins>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 
     </dependencies>
   </dependencyManagement>
-  
+
   <!-- This profile is used to allow github action to build branches. The github action is used for sonar analysis -->
   <profiles>
     <profile>


### PR DESCRIPTION
This change will delete JCabi Plugin usage in favor of AspectJ Plugin for AspectJ Annotation processing.