### PR TITLE
feat: Enhance Spring Bean API Definition - MEED-7576 - Meeds-io/meeds#2469

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/api/service/AnalyticsService.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/api/service/AnalyticsService.java
@@ -22,13 +22,20 @@ package io.meeds.analytics.api.service;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.stereotype.Service;
+import io.meeds.analytics.model.StatisticData;
+import io.meeds.analytics.model.StatisticFieldMapping;
+import io.meeds.analytics.model.StatisticFieldValue;
+import io.meeds.analytics.model.StatisticWatcher;
+import io.meeds.analytics.model.chart.ChartDataList;
+import io.meeds.analytics.model.chart.PercentageChartResult;
+import io.meeds.analytics.model.chart.PercentageChartValue;
+import io.meeds.analytics.model.chart.TableColumnResult;
+import io.meeds.analytics.model.filter.AnalyticsFilter;
+import io.meeds.analytics.model.filter.AnalyticsPercentageFilter;
+import io.meeds.analytics.model.filter.AnalyticsPeriod;
+import io.meeds.analytics.model.filter.AnalyticsPeriodType;
+import io.meeds.analytics.model.filter.AnalyticsTableFilter;
 
-import io.meeds.analytics.model.*;
-import io.meeds.analytics.model.chart.*;
-import io.meeds.analytics.model.filter.*;
-
-@Service
 public interface AnalyticsService {
 
   /**

--- a/analytics-api/src/main/java/io/meeds/analytics/api/service/StatisticDataQueueService.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/api/service/StatisticDataQueueService.java
@@ -19,14 +19,11 @@
  */
 package io.meeds.analytics.api.service;
 
-import org.springframework.stereotype.Service;
-
 import io.meeds.analytics.model.StatisticData;
 
 /**
  * A service to manage statistic data ingestion processing
  */
-@Service
 public interface StatisticDataQueueService {
 
   /**

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
@@ -51,7 +51,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import org.exoplatform.commons.api.settings.SettingService;
@@ -94,7 +93,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.Getter;
 
-@Primary
 @Service
 public class ElasticsearchAnalyticsService implements AnalyticsService {
 

--- a/analytics-services/src/main/java/io/meeds/analytics/queue/service/DummyStatisticDataQueueService.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/queue/service/DummyStatisticDataQueueService.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -45,7 +44,6 @@ import io.meeds.common.ContainerTransactional;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
-@Primary
 @Service
 public class DummyStatisticDataQueueService implements StatisticDataQueueService {
 


### PR DESCRIPTION
This change will allow to define API/Impl Spring Beans without having to declare the API as a Service Bean and the Implementation as Primary.