### PR TITLE
feat: Retrieve List of Space Ids in backend rather than frontend for Spaces List Widget - MEED-7673 - Meeds-io/meeds#2524

### DIFF
--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
@@ -20,6 +20,7 @@
 package io.meeds.analytics.portlet;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -32,7 +33,8 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.javascript.jscomp.jarjar.com.google.re2j.Pattern;
 
 import org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet;
-import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.webui.Utils;
 
 import io.meeds.analytics.api.service.AnalyticsService;
@@ -42,17 +44,23 @@ import io.meeds.analytics.utils.AnalyticsUtils;
 
 public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
 
-  private static final String        FROM_TIMESTAMP_PARAM = "{fromTimestamp}";
+  private static final String        FROM_TIMESTAMP_PARAM   = "{fromTimestamp}";
 
-  private static final String        TO_TIMESTAMP_PARAM   = "{toTimestamp}";
+  private static final String        TO_TIMESTAMP_PARAM     = "{toTimestamp}";
 
-  private static final String        SPACE_IDS_PARAM      = "{spaceIds}";
+  private static final String        SPACE_IDS_PARAM        = "{spaceIds}";
 
-  private static final Pattern       NUMBER_LIST_PATTERN  = Pattern.compile("[\\d,]*");
+  private static final String        SPACE_MEMBER_IDS_PARAM = "{spaceMemberIds}";
 
-  private static Map<String, String> filters              = new ConcurrentHashMap<>();
+  private static final Pattern       NUMBER_LIST_PATTERN    = Pattern.compile("[\\d,]*");
+
+  private static final int           MAX_SPACE_IDS          = 1000;
+
+  private static Map<String, String> filters                = new ConcurrentHashMap<>();
 
   private AnalyticsService           analyticsService;
+
+  private SpaceService               spaceService;
 
   @Override
   public final void serveResource(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
@@ -70,7 +78,6 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
     } else {
       filter.setLimit(Long.parseLong(limit));
     }
-
     ChartDataList result = getAnalyticsService().computeChartData(filter);
     response.getWriter().write(AnalyticsUtils.toJsonString(result));
     response.setContentType("application/json");
@@ -89,19 +96,23 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
       }
       filterString = filterString.replace(SPACE_IDS_PARAM, spaceIds);
     }
+    if (filterString.contains(SPACE_MEMBER_IDS_PARAM)) {
+      List<String> memberSpacesIds = getSpaceService().getMemberSpacesIds(request.getRemoteUser(), 0, MAX_SPACE_IDS);
+      filterString = filterString.replace(SPACE_MEMBER_IDS_PARAM, StringUtils.join(memberSpacesIds, ","));
+    }
     if (filterString.contains(FROM_TIMESTAMP_PARAM)) {
-      String spaceIds = request.getParameter("fromTimestamp");
-      if (!NUMBER_LIST_PATTERN.matches(spaceIds)) {
+      String fromTimestamp = request.getParameter("fromTimestamp");
+      if (!NUMBER_LIST_PATTERN.matches(fromTimestamp)) {
         throw new IllegalAccessException("Illegal Chars found in parameter 'fromTimestamp'");
       }
-      filterString = filterString.replace(FROM_TIMESTAMP_PARAM, spaceIds);
+      filterString = filterString.replace(FROM_TIMESTAMP_PARAM, fromTimestamp);
     }
     if (filterString.contains(TO_TIMESTAMP_PARAM)) {
-      String spaceIds = request.getParameter("toTimestamp");
-      if (!NUMBER_LIST_PATTERN.matches(spaceIds)) {
+      String toTimestamp = request.getParameter("toTimestamp");
+      if (!NUMBER_LIST_PATTERN.matches(toTimestamp)) {
         throw new IllegalAccessException("Illegal Chars found in parameter 'toTimestamp'");
       }
-      filterString = filterString.replace(TO_TIMESTAMP_PARAM, spaceIds);
+      filterString = filterString.replace(TO_TIMESTAMP_PARAM, toTimestamp);
     }
     return AnalyticsUtils.fromJsonString(filterString, AnalyticsFilter.class);
   }
@@ -112,9 +123,16 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
 
   private AnalyticsService getAnalyticsService() {
     if (analyticsService == null) {
-      analyticsService = CommonsUtils.getService(AnalyticsService.class);
+      analyticsService = ExoContainerContext.getService(AnalyticsService.class);
     }
     return analyticsService;
+  }
+
+  private SpaceService getSpaceService() {
+    if (spaceService == null) {
+      spaceService = ExoContainerContext.getService(SpaceService.class);
+    }
+    return spaceService;
   }
 
 }

--- a/analytics-webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -115,7 +115,7 @@
           }],
           "yAxisAggregation": {
             "type": "MAX",
-            "field": "id",
+            "field": "timestamp",
             "sortDirection": "desc"
           },
           "xAxisAggregations": [{
@@ -142,7 +142,7 @@
           }, {
             "field": "spaceId",
             "type": "IN_SET",
-            "valueString": "{spaceIds}"
+            "valueString": "{spaceMemberIds}"
           }, {
             "field": "timestamp",
             "type": "GREATER",
@@ -150,7 +150,7 @@
           }],
           "yAxisAggregation": {
             "type": "MAX",
-            "field": "id",
+            "field": "timestamp",
             "sortDirection": "desc"
           },
           "xAxisAggregations": [{
@@ -204,7 +204,7 @@
           }, {
             "field": "spaceId",
             "type": "IN_SET",
-            "valueString": "{spaceIds}"
+            "valueString": "{spaceMemberIds}"
           }, {
             "field": "timestamp",
             "type": "GREATER",

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/JsonPanelDrawer.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/JsonPanelDrawer.vue
@@ -33,7 +33,7 @@
         <textarea
           v-model="settingJsonContent"
           class="full-width full-height"
-          auto-grow />
+          auto-grow></textarea>
       </div>
     </template>
     <template #footer>

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
@@ -206,30 +206,21 @@ export default {
   methods: {
     refresh() {
       this.loading = true;
-      if (this.$root.spacesMemberOf) {
-        this.loading = true;
-        return this.getUserSpaces()
-          .finally(() => Promise.all([
-            this.getRecentyVisitedSpaces(),
-            this.getMostActiveSpaces(),
-          ]).finally(() => this.loading = false));
-      } else {
-        const getUserSpaces = this.$root.userSpacesLimit ?
-          this.getUserSpaces()
-          : Promise.resolve().then(() => this.$root.spaceIds = null);
-        return Promise.all([
-          this.getRecentyVisitedSpaces(),
-          this.getMostActiveSpaces(),
-          getUserSpaces,
-        ]).finally(() => this.loading = false);
-      }
+      const getUserSpaces = this.$root.userSpacesLimit ?
+        this.getUserSpaces()
+        : Promise.resolve().then(() => this.$root.spaceIds = null);
+      return Promise.all([
+        this.getRecentyVisitedSpaces(),
+        this.getMostActiveSpaces(),
+        getUserSpaces,
+      ]).finally(() => this.loading = false);
     },
     getUserSpaces() {
-      return this.$spaceService.getSpaces(null, 0, -1, 'member', 'spaceId')
+      return this.$spaceService.getSpaces(null, 0, this.$root.userSpacesLimit, 'member', 'spaceId')
         .then(data => this.$root.spaceIds = data?.spaces?.map(s => s.id) || []);
     },
     getRecentyVisitedSpaces() {
-      if (!this.$root.spacesRecentlyVisitedLimit || (this.$root.spacesMemberOf && !this.$root.spaceIds?.length)) {
+      if (!this.$root.spacesRecentlyVisitedLimit) {
         this.mostRecentSpaces = null;
         return Promise.resolve();
       }
@@ -237,7 +228,7 @@ export default {
         .then(data => this.mostRecentSpaces = data?.labels);
     },
     getMostActiveSpaces() {
-      if (!this.$root.spacesMostActiveLimit || this.$root.isExternal || (this.$root.spacesMemberOf && !this.$root.spaceIds?.length)) {
+      if (!this.$root.spacesMostActiveLimit || this.$root.isExternal) {
         this.mostActiveSpaces = null;
         return Promise.resolve();
       }
@@ -248,15 +239,7 @@ export default {
       if (this.$root.spacesMemberOf) {
         queryName += '.memberOnly';
       }
-      let url = `${this.$root.resourceURL}&queryName=${queryName}&xLimit=${limit}`;
-      if (this.$root.spacesMemberOf) {
-        const formData = new FormData();
-        formData.append('spaceIds', this.$root.spaceIds.join(','));
-        const params = new URLSearchParams(formData).toString();
-        url += `&${params}`;
-      }
-      url += `&fromTimestamp=${this.getPeriodTimestamp(period)}`;
-      return fetch(url)
+      return fetch(`${this.$root.resourceURL}&queryName=${queryName}&xLimit=${limit}&fromTimestamp=${this.getPeriodTimestamp(period)}`)
         .then(resp => resp?.ok && resp.json());
     },
     getPeriodTimestamp(period) {


### PR DESCRIPTION
Prior to this change, the list of recently visited spaces isn't updated in Spaces List widget due to two things:
- The List of Space Member Ids isn't completely retrieved, thus it has been improved to be computed in backend
- The id of analytics isn't the same as timestamp and thus isn't sortable anymore, thus the sort field has been changed to use the timestamp instead for 'Recently Visited Section'