### PR TITLE
FIX: [bug] [ANALYTICS] space host have access to action menu of analytics page - EXO-75352 - Meeds-io/meeds#2585

### DIFF
--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -254,11 +254,6 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
         return cacheChartModificationAccessPermission(portletSession, true);
       }
     }
-    Space space = SpaceUtils.getSpaceByContext();
-    if (space != null) {
-      boolean canModify = getSpaceService().canManageSpace(space, userId);
-      return cacheChartModificationAccessPermission(portletSession, canModify);
-    }
     return cacheChartModificationAccessPermission(portletSession, false);
   }
 


### PR DESCRIPTION
Before this fix, space managers could edit analytics settings in spaces.
This commit removes this ability so only the Analytics admin group members can do that.