### PR TITLE
FIX: [bug] [ANALYTICS] space host have access to action menu of analytics page - EXO-75352 - Meeds-io/meeds#2585

### DIFF
--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -254,11 +254,6 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
         return cacheChartModificationAccessPermission(portletSession, true);
       }
     }
-    Space space = SpaceUtils.getSpaceByContext();
-    if (space != null) {
-      boolean canModify = getSpaceService().canManageSpace(space, userId);
-      return cacheChartModificationAccessPermission(portletSession, canModify);
-    }
     return cacheChartModificationAccessPermission(portletSession, false);
   }
 


### PR DESCRIPTION
Prior to this fix, space managers were able to edit analytics settings in spaces this commit remove this ability so only members of the Analytics admin group can do that.

(cherry picked from commit cd2467f967bc6b5b0539941e0bafa2b68d99fcdf)