### PR TITLE
FIX: [bug] [ANALYTICS] space host have access to action menu of analytics page - EXO-75352 - Meeds-io/meeds#2585

### DIFF
--- a/analytics-webapps/src/main/java/org/exoplatform/addon/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/org/exoplatform/addon/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -251,11 +251,6 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
         return cacheChartModificationAccessPermission(portletSession, true);
       }
     }
-    Space space = SpaceUtils.getSpaceByContext();
-    if (space != null) {
-      boolean canModify = getSpaceService().isSuperManager(userId) || getSpaceService().isManager(space, userId);
-      return cacheChartModificationAccessPermission(portletSession, canModify);
-    }
     return cacheChartModificationAccessPermission(portletSession, false);
   }
 


### PR DESCRIPTION
Prior to this fix, space managers were able to edit analytics settings in spaces this commit remove this ability so only members of the Analytics admin group can do that.