### PR TITLE
FIX: Space host have access to action menu of analytics page - EXO-75352 - Meeds-io/meeds#2585

### DIFF
--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -256,7 +256,7 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
     }
     Space space = SpaceUtils.getSpaceByContext();
     if (space != null) {
-      boolean canModify = getSpaceService().canManageSpace(space, userId);
+      boolean canModify = getSpaceService().canManageSpaceLayout(space, userId);
       return cacheChartModificationAccessPermission(portletSession, canModify);
     }
     return cacheChartModificationAccessPermission(portletSession, false);


### PR DESCRIPTION
Prior to this fix, space managers were able to edit analytics settings in spaces this commit change this to grant this permission to members having "Edit navigation" permission.