### PR TITLE
fix: When the user is not a member of any space, AnalyticsQueryPortlet generates an error - MEED-8706

### DIFF
--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
@@ -98,6 +98,9 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
     }
     if (filterString.contains(SPACE_MEMBER_IDS_PARAM)) {
       List<String> memberSpacesIds = getSpaceService().getMemberSpacesIds(request.getRemoteUser(), 0, MAX_SPACE_IDS);
+      if (memberSpacesIds.isEmpty()) {
+        memberSpacesIds.add("-1");
+      }
       filterString = filterString.replace(SPACE_MEMBER_IDS_PARAM, StringUtils.join(memberSpacesIds, ","));
     }
     if (filterString.contains(FROM_TIMESTAMP_PARAM)) {


### PR DESCRIPTION
Before this fix, when the user is not member of any space, the AnalyticsQueryPortlet generates an error when sending the request to ES : the field SPACE_ID with type IN_SET does do not accept empty value. To prevent that, if the space list is empty, we add the spaceId -1 which not exists to be sure to return no spaces

Resolves meeds-io/meeds#3190

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
