### PR TITLE
fix: Add invisible indexed in analytics profile setting properties to user statistics - MEED-8755 - Meeds-io/meeds#3208

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -540,8 +540,7 @@ public class AnalyticsUtils {
       Map<String, Object> properties = identity.getProfile().getProperties();
       List<ProfilePropertySetting> propertySettings = getProfilePropertyService().getPropertySettings();
       propertySettings.stream()
-                      .filter(profilePropertySetting -> profilePropertySetting.isVisible()
-                          && profilePropertySetting.isIndexInAnalytics())
+                      .filter(ProfilePropertySetting::isIndexInAnalytics)
                       .forEach(property -> {
                         String propertyName = property.getPropertyName();
                         Object propertyValue = properties.get(propertyName);


### PR DESCRIPTION


Prior to this change, the indexed in analytics and invisible profile setting properties were not present in the user statistics. This change adds those properties to the analytics user statistics.
Resolves https://github.com/Meeds-io/meeds/issues/3208

