### PR TITLE
fix: fix: Ensure latest mapping is used by sorting indices by creation date during field mapping generation - MEED-8848 - Meeds-io/meeds#3226

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -32,20 +32,17 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
 import java.time.temporal.IsoFields;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TimeZone;
+import java.util.*;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.time.LocalDate;
 
-import org.apache.commons.lang3.ArrayUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
@@ -118,6 +115,8 @@ public class AnalyticsUtils {
   public static final String            ACTIVITY_COMMENT                 = "comment";
 
   public static final String            PROFILE_PROPERTIES               = "profileProperties";
+  
+  private static final String           PROPERTIES                       = "properties";
 
   public static final List<String>      COMPUTED_CHART_LABEL             = Arrays.asList(FIELD_MODIFIER_USER_SOCIAL_ID,                                 // NOSONAR
                                                                                          FIELD_SOCIAL_IDENTITY_ID,
@@ -293,40 +292,39 @@ public class AnalyticsUtils {
     return new JSONArray(valuesList.stream().map(String::trim).toList()).toString();
   }
 
-  public static JSONObject getJSONObject(JSONObject jsonObject, int i, String... keys) { // NOSONAR
+  public static JsonNode getJsonNode(JsonNode jsonNode, int i, String... keys) {
     if (keys == null || i >= keys.length) {
       return null;
     }
     try {
       if (keys[i] == null) {
-        String[] names = JSONObject.getNames(jsonObject);
-        if (ArrayUtils.isNotEmpty(names)) {
-          i++;
-          JSONObject resultJsonObject = new JSONObject();
-          for (String name : names) {
-            JSONObject subJsonObject = jsonObject.getJSONObject(name);
-            JSONObject resultSubJsonObject = getJSONObject(subJsonObject, i, keys);
-
-            if (resultSubJsonObject != null) {
-              mergeKeyMappings(resultJsonObject, resultSubJsonObject);
-            }
-          }
-          return resultJsonObject;
-        } else {
+        Iterator<String> fieldNames = jsonNode.fieldNames();
+        if (!fieldNames.hasNext()) {
           return null;
         }
-      } else if (jsonObject.has(keys[i])) {
-        jsonObject = jsonObject.getJSONObject(keys[i]);
+        ObjectNode resultNode = JsonNodeFactory.instance.objectNode();
+        while (fieldNames.hasNext()) {
+          String fieldName = fieldNames.next();
+          JsonNode subNode = jsonNode.get(fieldName);
+          JsonNode resultSubNode = getJsonNode(subNode, i + 1, keys);
+
+          if (resultSubNode != null && resultSubNode.isObject()) {
+            mergeObjectNodes(resultNode, (ObjectNode) resultSubNode);
+          }
+        }
+        return resultNode;
+      } else if (jsonNode.has(keys[i])) {
+        JsonNode nextNode = jsonNode.get(keys[i]);
         i++;
         if (i == keys.length) {
-          return jsonObject;
+          return nextNode;
         } else {
-          return getJSONObject(jsonObject, i, keys);
+          return getJsonNode(nextNode, i, keys);
         }
       } else {
         return null;
       }
-    } catch (JSONException e) {
+    } catch (Exception e) {
       LOG.warn("Error getting key object with {}", keys[i], e);
       return null;
     }
@@ -561,23 +559,75 @@ public class AnalyticsUtils {
     }
   }
 
-  private static void mergeKeyMappings(JSONObject target, JSONObject source) {
-    for (String key : JSONObject.getNames(source)) {
-      Object newValue = source.get(key);
+  private static void mergeObjectNodes(ObjectNode target, ObjectNode source) {
+    for (Iterator<Map.Entry<String, JsonNode>> it = source.fields(); it.hasNext();) {
+      Map.Entry<String, JsonNode> entry = it.next();
+      String key = entry.getKey();
+      JsonNode newValue = entry.getValue();
       if (!target.has(key)) {
-        target.put(key, newValue);
-      } else {
-        Object existingValue = target.get(key);
-        if (existingValue instanceof JSONObject && newValue instanceof JSONObject) {
-          mergeKeyMappings((JSONObject) existingValue, (JSONObject) newValue);
+        target.set(key, newValue);
+        continue;
+      }
+      JsonNode existingValue = target.get(key);
+      if (existingValue.isObject() && newValue.isObject()) {
+        ObjectNode existingObj = (ObjectNode) existingValue;
+        ObjectNode newObj = (ObjectNode) newValue;
+        JsonNode existingProps = existingObj.get(PROPERTIES);
+        JsonNode newProps = newObj.get(PROPERTIES);
+        if (existingProps != null && newProps != null && existingProps.isObject() && newProps.isObject()) {
+          ObjectNode existingPropsObj = (ObjectNode) existingProps;
+          ObjectNode newPropsObj = (ObjectNode) newProps;
+          if (hasNewKeys(existingPropsObj, newPropsObj)) {
+            mergeObjectNodes(existingPropsObj, newPropsObj);
+            existingObj.set(PROPERTIES, existingPropsObj);
+          }
+          target.set(key, existingObj);
         } else {
-          target.put(key, newValue);
+          target.set(key, newValue);
         }
+      } else {
+        target.set(key, newValue);
       }
     }
   }
 
-  
+  private static boolean hasNewKeys(ObjectNode existing, ObjectNode incoming) {
+    Iterator<String> it = incoming.fieldNames();
+    while (it.hasNext()) {
+      if (!existing.has(it.next())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static ObjectNode sortByAnalyticsDate(JSONObject input) {
+    Map<LocalDate, String> dateKeyMap = new TreeMap<>();
+    Pattern pattern = Pattern.compile("analytics_(\\d{4}-\\d{2}-\\d{2})");
+
+    for (String key : input.keySet()) {
+      Matcher matcher = pattern.matcher(key);
+      if (matcher.matches()) {
+        LocalDate date = LocalDate.parse(matcher.group(1));
+        dateKeyMap.put(date, key);
+      }
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode sortedNode = mapper.createObjectNode();
+
+    for (Map.Entry<LocalDate, String> entry : dateKeyMap.entrySet()) {
+      String key = entry.getValue();
+      Object raw = input.get(key);
+      try {
+        JsonNode valueNode = mapper.readTree(raw.toString());
+        sortedNode.set(key, valueNode);
+      } catch (Exception e) {
+        sortedNode.putPOJO(key, raw);
+      }
+    }
+    return sortedNode;
+  }
+
   private static ProfilePropertyService getProfilePropertyService() {
     if (profilePropertyService == null) {
       profilePropertyService = CommonsUtils.getService(ProfilePropertyService.class);

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
@@ -19,14 +19,6 @@
  */
 package io.meeds.analytics.elasticsearch.service;
 
-import static io.meeds.analytics.utils.AnalyticsUtils.DEFAULT_FIELDS;
-import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_TIMESTAMP;
-import static io.meeds.analytics.utils.AnalyticsUtils.collectionToJSONString;
-import static io.meeds.analytics.utils.AnalyticsUtils.fixJSONStringFormat;
-import static io.meeds.analytics.utils.AnalyticsUtils.fromJsonString;
-import static io.meeds.analytics.utils.AnalyticsUtils.getJSONObject;
-import static io.meeds.analytics.utils.AnalyticsUtils.toJsonString;
-
 import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -45,6 +37,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -94,6 +88,8 @@ import io.meeds.common.ContainerTransactional;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.Getter;
+
+import static io.meeds.analytics.utils.AnalyticsUtils.*;
 
 @Service
 public class ElasticsearchAnalyticsService implements AnalyticsService {
@@ -213,8 +209,8 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
         return new HashSet<>(esMappings.values());
       }
 
-      JSONObject result = new JSONObject(mappingJsonString);
-      JSONObject mappingObject = getJSONObject(result, 0, null, "mappings", "properties");
+      ObjectNode result = sortByAnalyticsDate(new JSONObject(mappingJsonString));
+      JsonNode mappingObject = getJsonNode(result, 0, null, "mappings", "properties");
 
       if (mappingObject != null) {
         processFields(mappingObject, "", esMappings);
@@ -1380,24 +1376,29 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
     return Objects.toString(value, null);
   }
 
-  private void processFields(JSONObject fieldsObject, String parentPath, Map<String, StatisticFieldMapping> esMappings) {
-    String[] fieldNames = JSONObject.getNames(fieldsObject);
-    if (fieldNames == null) {
+  private void processFields(JsonNode fieldsNode, String parentPath, Map<String, StatisticFieldMapping> esMappings) {
+    if (fieldsNode == null || !fieldsNode.isObject()) {
       return;
     }
-    for (String fieldName : fieldNames) {
-      JSONObject esField = fieldsObject.getJSONObject(fieldName);
-      if (esField == null) {
+    Iterator<Map.Entry<String, JsonNode>> fields = fieldsNode.fields();
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> entry = fields.next();
+      String fieldName = entry.getKey();
+      JsonNode esField = entry.getValue();
+
+      if (esField == null || !esField.isObject()) {
         continue;
       }
-      // Handle nested fields with "properties"
       if (esField.has("properties")) {
-        processFields(esField.getJSONObject("properties"), parentPath + fieldName + ".", esMappings);
+        JsonNode nestedProperties = esField.get("properties");
+        processFields(nestedProperties, parentPath + fieldName + ".", esMappings);
       } else if (esField.has("type")) {
         // Process regular fields with a "type"
-        String fieldType = esField.getString("type");
-        JSONObject keywordField = getJSONObject(esField, 0, "fields", "keyword");
-        StatisticFieldMapping esFieldMapping = new StatisticFieldMapping(parentPath + fieldName, fieldType, keywordField != null);
+        String fieldType = esField.get("type").asText();
+        JsonNode keywordField = getJsonNode(esField, 0, "fields", "keyword");
+        boolean hasKeyword = keywordField != null && keywordField.isObject();
+        StatisticFieldMapping esFieldMapping = new StatisticFieldMapping(parentPath + fieldName, fieldType, hasKeyword);
+
         esMappings.put(parentPath + fieldName, esFieldMapping);
       }
     }


### PR DESCRIPTION
Sort the analytic indices by their creation date when retrieving stored mappings. This ensures that we always select the most recent mapping from the latest index, allowing the system to correctly display the most up-to-date data.
fixes Meeds-io/meeds#3226