### PR TITLE
fix: Fix displayed "null" value for chartOptions tooltip in Analytics Portlet portlet with single chart - MEED-8963 - Meeds-io/meeds#3276

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
@@ -114,7 +114,9 @@ export default {
         } else {
           chartOptions.xAxis[0].axisTick = {alignWithLabel: true};
         }
-
+        if (charts.length === 1 && (!charts[0].chartLabel || charts[0].chartLabel === 'null')) {
+          chartOptions.tooltip.formatter = '<center>{c}</center>';
+        }
         const isMultipleCharts = charts.length > 1;
         charts.forEach(chartData => {
           const serie = {


### PR DESCRIPTION
Prior to this change, when the AnalyticsPortlet portlet is configured with a single chart the chartOption tooltip displays null value for horizantal axis title. After this commit, we ensure to display this information only for multiple charts case only.

Resolves https://github.com/Meeds-io/meeds/issues/3276