### PR TITLE
fix: Allow to have Statistic Collection JS in all pages - MEED-9310 - Meeds-io/meeds#3423

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/dynamic-container-configuration.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/conf/analytics/dynamic-container-configuration.xml
@@ -48,7 +48,7 @@
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>left-topNavigation-container</value>
+          <value>body-end-container</value>
         </value-param>
         <object-param>
           <name>statistics-portlet</name>


### PR DESCRIPTION
Prior to this change, the Statistic Collections JS wasn't defined in all pages including those which hides shared layout. This change will allow to initiate statistic collections even on standalone pages.

Resolves Meeds-io/meeds#3423