### PR TITLE
fix: Analytics parsing error - MEED-9542 - meeds-io/meeds#3494

### DIFF
--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
@@ -337,7 +337,7 @@ public class ElasticsearchAnalyticsStorage {
       document.setListFields(data.getListParameters());
     }
     JSONObject createRequest = new JSONObject();
-    createRequest.put("create", jsonObject);
+    createRequest.put("index", jsonObject);
     return createRequest.toString() + "\n" + document.toJSON() + "\n";
   }
 


### PR DESCRIPTION
before this change, when add a field value from current user profile which corresponds to an integer then browse to some pages in order to create some analytics entries with the value of property and change the property value to be a String, an exception is triggered about analytics mapping which designed a property as integer. To fix this problem, silently overwrite existing documents and eliminate version_conflict_engine_exception errors. After this change, The property value type change does not cause such error.
