### PR TITLE
fix: Improve Analytics Fields Mapping Dynamic Creation - MEED-9542 - Meeds-io/meeds#3494

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
@@ -27,14 +27,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
-@ToString
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class StatisticData implements Serializable {
@@ -43,56 +43,34 @@ public class StatisticData implements Serializable {
 
   private static final int                PRIME            = 59;
 
+  private final String                    uuid             = UUID.randomUUID().toString();
+
   @ToString.Exclude
   private DateFormat                      dateFormat;
 
-  @Getter
-  @Setter
   private long                            timestamp;
 
-  @Getter
-  @Setter
   private long                            userId;
 
-  @Getter
-  @Setter
   private long                            spaceId;
 
-  @Getter
-  @Setter
   private String                          module;
 
-  @Getter
-  @Setter
   private String                          subModule;
 
-  @Getter
-  @Setter
   private String                          operation;
 
-  @Getter
-  @Setter
   private StatisticStatus                 status           = StatisticStatus.OK;
 
-  @Getter
-  @Setter
   private String                          errorMessage;
 
-  @Getter
-  @Setter
   private long                            duration;
 
-  @Getter
-  @Setter
   private long                            errorCode;
 
-  @Getter
-  @Setter
-  private Map<String, String>             parameters;
+  private Map<String, Object>             parameters;
 
-  @Getter
-  @Setter
-  private Map<String, Collection<String>> listParameters;
+  private Map<String, Collection<Object>> listParameters;
 
   public void addParameter(String key, Object value) {
     if (parameters == null) {
@@ -103,7 +81,7 @@ public class StatisticData implements Serializable {
     }
     if (value instanceof Collection) {
       Collection<?> collection = (Collection<?>) value;
-      Collection<String> values = collection.stream()
+      Collection<Object> values = collection.stream()
                                             .filter(Objects::nonNull)
                                             .map(this::getFieldValue)
                                             .toList();
@@ -116,9 +94,11 @@ public class StatisticData implements Serializable {
     }
   }
 
-  private String getFieldValue(Object value) {
+  private Object getFieldValue(Object value) {
     if (value instanceof Date) {
       return buildDateFormat().format(value);
+    } else if (value == null || value.getClass().isPrimitive()) {
+      return value;
     } else {
       return String.valueOf(value);
     }
@@ -132,8 +112,7 @@ public class StatisticData implements Serializable {
   }
 
   public enum StatisticStatus {
-    OK,
-    KO;
+    OK, KO;
   }
 
   public long computeId() {
@@ -144,6 +123,7 @@ public class StatisticData implements Serializable {
     result = result * PRIME + (subModule == null ? 43 : subModule.hashCode());
     result = result * PRIME + (operation == null ? 43 : operation.hashCode());
     result = result * PRIME + (parameters == null ? 43 : parameters.hashCode());
+    result = result * PRIME + uuid.hashCode();
     return result;
   }
 

--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -544,7 +544,8 @@ public class AnalyticsUtils {
                         if (properties.containsKey(propertyName)) {
                           if (propertyValue instanceof String value) {
                             statisticData.addParameter(String.join(".", PROFILE_PROPERTIES, propertyName), value);
-                          } else if (propertyValue instanceof List<?> values && !property.isHasChildProperties()) {
+                          } else if (!property.isHasChildProperties()
+                              && propertyValue instanceof List<?> values) {
                             @SuppressWarnings("unchecked")
                             List<Map<String, String>> multiValues = (List<Map<String, String>>) values;
                             List<String> valuesList = multiValues.stream()

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityListener.java
@@ -229,7 +229,7 @@ public class AnalyticsActivityListener extends ActivityListenerPlugin {
         Space space = spaceService.getSpaceByPrettyName(streamIdentity.getRemoteId());
         addSpaceStatistics(statisticData, space);
       }
-      statisticData.addParameter("streamIdentityId", Long.parseLong(streamIdentity.getId()));
+      statisticData.addParameter("streamIdentityId", streamIdentity.getIdentityId());
     }
 
     statisticData.setModule("social");

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityTagsListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityTagsListener.java
@@ -90,7 +90,7 @@ public class AnalyticsActivityTagsListener extends Listener<TagObject, Set<TagNa
     statisticData.addParameter("username", username);
     statisticData.addParameter("type", objectType);
     statisticData.addParameter("dataType", StringUtils.lowerCase(objectType));
-    statisticData.addParameter("spaceId", audienceIdentity.getId());
+    statisticData.addParameter("spaceIdentityId", audienceIdentity.getIdentityId());
 
     for (int i = 0; i < numberOfTags; i++) {
       AnalyticsUtils.addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsProfileListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsProfileListener.java
@@ -132,7 +132,7 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
     statisticData.setSubModule("profile");
     statisticData.setOperation(operation);
     statisticData.setUserId(Long.parseLong(identity.getId()));
-    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, Long.parseLong(identity.getId()));
+    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, identity.getIdentityId());
     statisticData.addParameter("userCreatedDate", identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
     return statisticData;
   }

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/listener/ElasticsearchMappingListener.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/listener/ElasticsearchMappingListener.java
@@ -1,0 +1,55 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.analytics.elasticsearch.listener;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerBase;
+import org.exoplatform.services.listener.ListenerService;
+
+import io.meeds.analytics.api.service.AnalyticsService;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+@Asynchronous
+public class ElasticsearchMappingListener implements ListenerBase<String, String> {
+
+  public static final String FIELD_MAPPING_CREATED_EVENT = "analytics.field.mapping.created";
+
+  @Autowired
+  private AnalyticsService   analyticsService;
+
+  @Autowired
+  private ListenerService    listenerService;
+
+  @PostConstruct
+  public void init() {
+    listenerService.addListener(FIELD_MAPPING_CREATED_EVENT, this);
+  }
+
+  @Override
+  public void onEvent(Event<String, String> event) throws Exception {
+    analyticsService.retrieveMapping(true);
+  }
+
+}

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
@@ -88,11 +88,16 @@ import io.meeds.common.ContainerTransactional;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.Getter;
+import lombok.Synchronized;
 
 import static io.meeds.analytics.utils.AnalyticsUtils.*;
 
 @Service
 public class ElasticsearchAnalyticsService implements AnalyticsService {
+
+  private static final String                MAPPINGS_SUB_NODE                        = "mappings";
+
+  private static final String                PROPERTIES_SUB_NODE                      = "properties";
 
   private static final String                VALUE_PARAM                              = "value";
 
@@ -195,6 +200,7 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
   }
 
   @Override
+  @Synchronized
   @ContainerTransactional
   public Set<StatisticFieldMapping> retrieveMapping(boolean forceRefresh) {
     if (!forceRefresh) {
@@ -204,13 +210,14 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
       return new HashSet<>(esMappings.values());
     }
     try {
+      LOG.info("Retrieve Elasticsearch Field Mappings");
       String mappingJsonString = elasticsearchStorage.retrieveAllAnalyticsIndexesMapping();
       if (StringUtils.isBlank(mappingJsonString)) {
         return new HashSet<>(esMappings.values());
       }
 
       ObjectNode result = sortByAnalyticsDate(new JSONObject(mappingJsonString));
-      JsonNode mappingObject = getJsonNode(result, 0, null, "mappings", "properties");
+      JsonNode mappingObject = getJsonNode(result, 0, null, MAPPINGS_SUB_NODE, PROPERTIES_SUB_NODE);
 
       if (mappingObject != null) {
         processFields(mappingObject, "", esMappings);
@@ -1376,21 +1383,21 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
     return Objects.toString(value, null);
   }
 
-  private void processFields(JsonNode fieldsNode, String parentPath, Map<String, StatisticFieldMapping> esMappings) {
+  private void processFields(JsonNode fieldsNode,
+                             String parentPath,
+                             Map<String, StatisticFieldMapping> esMappings) {
     if (fieldsNode == null || !fieldsNode.isObject()) {
       return;
     }
-    Iterator<Map.Entry<String, JsonNode>> fields = fieldsNode.fields();
+    Iterator<Map.Entry<String, JsonNode>> fields = fieldsNode.properties().iterator();
     while (fields.hasNext()) {
       Map.Entry<String, JsonNode> entry = fields.next();
       String fieldName = entry.getKey();
       JsonNode esField = entry.getValue();
-
       if (esField == null || !esField.isObject()) {
-        continue;
-      }
-      if (esField.has("properties")) {
-        JsonNode nestedProperties = esField.get("properties");
+        continue; // NOSONAR
+      } else if (esField.has(PROPERTIES_SUB_NODE)) {
+        JsonNode nestedProperties = esField.get(PROPERTIES_SUB_NODE);
         processFields(nestedProperties, parentPath + fieldName + ".", esMappings);
       } else if (esField.has("type")) {
         // Process regular fields with a "type"
@@ -1403,4 +1410,5 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
       }
     }
   }
+
 }

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchStatisticDataProcessorService.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchStatisticDataProcessorService.java
@@ -34,6 +34,9 @@ public class ElasticsearchStatisticDataProcessorService implements StatisticData
   @Autowired
   private ElasticsearchAnalyticsStorage elasticsearchStorage;
 
+  @Autowired
+  private ElasticsearchAnalyticsService elasticsearchAnalyticsService;
+
   @Override
   public String getId() {
     return "analytics.processor.elasticsearch";
@@ -41,7 +44,7 @@ public class ElasticsearchStatisticDataProcessorService implements StatisticData
 
   @Override
   public void process(List<StatisticDataQueueEntry> processorQueueEntries) {
-    elasticsearchStorage.sendCreateBulkDocumentsRequest(processorQueueEntries);
+    elasticsearchStorage.sendCreateBulkDocumentsRequest(processorQueueEntries, elasticsearchAnalyticsService.retrieveMapping(false));
   }
 
 }

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
@@ -19,6 +19,7 @@
  */
 package io.meeds.analytics.elasticsearch.storage;
 
+import static io.meeds.analytics.elasticsearch.listener.ElasticsearchMappingListener.FIELD_MAPPING_CREATED_EVENT;
 import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_DURATION;
 import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_ERROR_CODE;
 import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_ERROR_MESSAGE;
@@ -32,17 +33,26 @@ import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_TIMESTAMP;
 import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_USER_ID;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
@@ -65,18 +75,30 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import org.exoplatform.commons.search.domain.Document;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
 import io.meeds.analytics.elasticsearch.model.ElasticsearchResponse;
 import io.meeds.analytics.model.StatisticData;
 import io.meeds.analytics.model.StatisticDataQueueEntry;
+import io.meeds.analytics.model.StatisticFieldMapping;
 
 import jakarta.annotation.PostConstruct;
 import lombok.SneakyThrows;
 
 @Component
 public class ElasticsearchAnalyticsStorage {
+
+  private static final String           TEXT_MAPPING_TYPE    = "text";
+
+  private static final String           KEYWORD_MAPPING_TYPE = "keyword";
+
+  private static final String           BOOLEAN_MAPPING_TYPE = "boolean";
+
+  private static final String           FLOAT_MAPPING_TYPE   = "float";
+
+  private static final String           LONG_MAPPING_TYPE    = "long";
 
   private static final Log              LOG                =
                                             ExoLogger.getExoLogger(ElasticsearchAnalyticsStorage.class);
@@ -87,6 +109,11 @@ public class ElasticsearchAnalyticsStorage {
 
   public static final DateTimeFormatter DAY_DATE_FORMATTER = DateTimeFormatter.ofPattern(DAY_DATE_FORMAT)
                                                                               .withResolverStyle(ResolverStyle.LENIENT);
+
+  private List<String>                  ignoredFieldNames    = Collections.synchronizedList(new ArrayList<>());
+
+  @Autowired
+  private ListenerService               listenerService;
 
   @Autowired
   private ElasticsearchConfiguration    elasticsearchConfiguration;
@@ -105,7 +132,8 @@ public class ElasticsearchAnalyticsStorage {
     }
   }
 
-  public void sendCreateBulkDocumentsRequest(List<StatisticDataQueueEntry> dataQueueEntries) {
+  public void sendCreateBulkDocumentsRequest(List<StatisticDataQueueEntry> dataQueueEntries,
+                                             Set<StatisticFieldMapping> esMappings) {
     if (dataQueueEntries == null || dataQueueEntries.isEmpty()) {
       return;
     }
@@ -116,7 +144,8 @@ public class ElasticsearchAnalyticsStorage {
     StringBuilder request = new StringBuilder();
     for (StatisticDataQueueEntry statisticDataQueueEntry : dataQueueEntries) {
       String singleDocumentQuery = getCreateDocumentRequestContent(String.valueOf(statisticDataQueueEntry.getId()),
-                                                                   statisticDataQueueEntry.getStatisticData());
+                                                                   statisticDataQueueEntry.getStatisticData(),
+                                                                   esMappings);
       request.append(singleDocumentQuery);
     }
 
@@ -308,7 +337,9 @@ public class ElasticsearchAnalyticsStorage {
         "}";
   }
 
-  private String getCreateDocumentRequestContent(String id, StatisticData data) {
+  private String getCreateDocumentRequestContent(String id,
+                                                 StatisticData data,
+                                                 Set<StatisticFieldMapping> esMappings) {
     JSONObject jsonObject = createCUDHeaderRequestContent(id);
     String timestampString = String.valueOf(data.getTimestamp());
 
@@ -325,20 +356,150 @@ public class ElasticsearchAnalyticsStorage {
     fields.put(FIELD_ERROR_MESSAGE, data.getErrorMessage());
     fields.put(FIELD_DURATION, String.valueOf(data.getDuration()));
     fields.put(FIELD_IS_ANALYTICS, "true");
-    if (data.getParameters() != null && !data.getParameters().isEmpty()) {
-      fields.putAll(data.getParameters());
+    Map<String, StatisticFieldMapping> mappedFields = esMappings.stream()
+                                                                .collect(Collectors.toMap(StatisticFieldMapping::getName,
+                                                                                          Function.identity()));
+    if (MapUtils.isNotEmpty(data.getParameters())) {
+      data.getParameters()
+          .keySet()
+          .stream()
+          .filter(p -> !mappedFields.containsKey(p))
+          .forEach(f -> createFieldMapping(f, data.getParameters().get(f)));
+      Map<String, String> parameters = data.getParameters()
+                                           .entrySet()
+                                           .stream()
+                                           .filter(e -> e.getValue() != null && StringUtils.isNotBlank(e.getValue().toString()))
+                                           .filter(e -> {
+                                             String name = e.getKey();
+                                             Object value = e.getValue();
+                                             StatisticFieldMapping mapping = mappedFields.get(name);
+                                             if (checkFieldMapping(value, mapping)) {
+                                               return true;
+                                             } else {
+                                               if (!ignoredFieldNames.contains(name)) {
+                                                 ignoredFieldNames.add(name);
+                                                 LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
+                                                          name,
+                                                          getFieldMappingType(value),
+                                                          mapping.getType());
+                                               }
+                                               return false;
+                                             }
+                                           })
+                                           .collect(Collectors.toMap(Entry::getKey, e -> getFieldValue(e.getValue())));
+      fields.putAll(parameters);
     }
     Document document = new Document(String.valueOf(id),
                                      null,
                                      null,
                                      (Set<String>) null,
                                      fields);
-    if (data.getListParameters() != null && !data.getListParameters().isEmpty()) {
-      document.setListFields(data.getListParameters());
+    if (MapUtils.isNotEmpty(data.getListParameters())) {
+      data.getListParameters()
+          .keySet()
+          .stream()
+          .filter(p -> !mappedFields.containsKey(p))
+          .filter(p -> CollectionUtils.isNotEmpty(data.getListParameters().get(p)))
+          .forEach(p -> createFieldMapping(p, data.getListParameters().get(p)));
+      Map<String, Collection<String>> parameters = data.getListParameters()
+                                                       .entrySet()
+                                                       .stream()
+                                                       .filter(e -> CollectionUtils.isNotEmpty(e.getValue()))
+                                                       .filter(e -> {
+                                                         Collection<Object> value = e.getValue();
+                                                         String name = e.getKey();
+                                                         StatisticFieldMapping mapping = mappedFields.get(name);
+                                                         if (checkFieldMapping(value, mapping)) {
+                                                           return true;
+                                                         } else {
+                                                           if (!ignoredFieldNames.contains(name)) {
+                                                             ignoredFieldNames.add(name);
+                                                             LOG.warn("Field with name '{}' doesn't have the expected type {} in ES ('{}'). Ignore adding it in indexed document.",
+                                                                      name,
+                                                                      getFieldMappingType(value),
+                                                                      mapping.getType());
+                                                           }
+                                                           return false;
+                                                         }
+                                                       })
+                                                       .collect(Collectors.toMap(Entry::getKey,
+                                                                                 e -> getFieldValue(e.getValue())));
+      document.setListFields(parameters);
     }
     JSONObject createRequest = new JSONObject();
     createRequest.put("create", jsonObject);
     return createRequest.toString() + "\n" + document.toJSON() + "\n";
+  }
+
+  private void createFieldMapping(String f, Object value) {
+    String type = getFieldMappingType(value);
+    try {
+      sendPutRequest(elasticsearchConfiguration.getIndexAlias() + "/_mapping", String.format("""
+          {
+            "properties": {
+              "%s" : {
+                "type" : "%s"
+              }
+            }
+          }
+          """, f, type));
+      LOG.info("Create ES Mapping for field '{}' with type '{}'", f, type);
+      listenerService.broadcast(FIELD_MAPPING_CREATED_EVENT, f, type);
+    } catch (Exception e) {
+      LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists.",
+               f,
+               type,
+               e);
+    }
+  }
+
+  private boolean checkFieldMapping(Object value, StatisticFieldMapping mapping) {
+    if (mapping == null) {
+      return true;
+    } else {
+      String fieldMappingType = getFieldMappingType(value);
+      String mappedType = mapping.getType();
+      if (StringUtils.equalsIgnoreCase(mappedType, fieldMappingType)) {
+        return true;
+      } else {
+        return switch (mappedType) {
+        case LONG_MAPPING_TYPE -> StringUtils.isNumeric(value.toString());
+        case FLOAT_MAPPING_TYPE -> LONG_MAPPING_TYPE.equals(fieldMappingType);
+        case BOOLEAN_MAPPING_TYPE -> StringUtils.equalsAny(value.toString(), "true", "false");
+        case KEYWORD_MAPPING_TYPE -> true;
+        case TEXT_MAPPING_TYPE -> true;
+        default -> false;
+        };
+      }
+    }
+  }
+
+  private String getFieldMappingType(Object value) {
+    return switch (value) {
+    case Integer v -> LONG_MAPPING_TYPE;
+    case Long v -> LONG_MAPPING_TYPE;
+    case Byte v -> LONG_MAPPING_TYPE;
+    case Float v -> FLOAT_MAPPING_TYPE;
+    case Double v -> FLOAT_MAPPING_TYPE;
+    case Boolean v -> BOOLEAN_MAPPING_TYPE;
+    case Collection<?> v -> getFieldMappingType(v.toArray()[0]);
+    default -> KEYWORD_MAPPING_TYPE;
+    };
+  }
+
+  private String getFieldValue(Object value) {
+    return switch (value) {
+    case Integer v -> BigDecimal.valueOf(v).toPlainString();
+    case Long v -> BigDecimal.valueOf(v).toPlainString();
+    case Byte v -> BigDecimal.valueOf(v).toPlainString();
+    case Float v -> BigDecimal.valueOf(v).toPlainString();
+    case Double v -> BigDecimal.valueOf(v).toPlainString();
+    default -> String.valueOf(value);
+    };
+  }
+
+  private Collection<String> getFieldValue(Collection<Object> value) {
+    return value.stream().map(this::getFieldValue).toList();
   }
 
   private JSONObject createCUDHeaderRequestContent(String id) {
@@ -378,9 +539,9 @@ public class ElasticsearchAnalyticsStorage {
     }
     if (StringUtils.contains(response.getMessage(), "\"errors\":true")) {
       if (StringUtils.contains(response.getMessage(), "\"type\":\"version_conflict_engine_exception\"")
-          && StringUtils.countMatches(response.getMessage(),"{\"create\":{") == 1) {
-        //the ES response is not answer of a bulk, but of a single insert
-        //it means the entry already exists in ES, no need to raise an error
+          && StringUtils.countMatches(response.getMessage(), "{\"create\":{") == 1) {
+        // the ES response is not answer of a bulk, but of a single insert
+        // it means the entry already exists in ES, no need to raise an error
         LOG.warn("ID conflict in some content: {}", response.getMessage());
       } else {
         throw new IllegalStateException(String.format("Error message returned from ES: %s. URI: %s. Content: %s",

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchConfiguration.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchConfiguration.java
@@ -146,7 +146,7 @@ public class ElasticsearchConfiguration {
 
   @SneakyThrows
   private void computeIndexTemplateMapping() {
-    InputStream mappingFileIS = getClass().getClassLoader().getResourceAsStream("analytics-es-template.json");
+    InputStream mappingFileIS = getClass().getClassLoader().getResourceAsStream(indexTemplateMappingFilePath);
     indexTemplateMapping = IOUtil.getStreamContentAsString(mappingFileIS);
     indexTemplateMapping = indexTemplateMapping.replace(ElasticsearchConfiguration.DEFAULT_ES_INDEX_TEMPLATE,
                                                         getIndexAlias())

--- a/analytics-services/src/main/resources/analytics-es-template.json
+++ b/analytics-services/src/main/resources/analytics-es-template.json
@@ -11,7 +11,7 @@
       "number_of_replicas": replica.number
     },
     "mappings": {
-      "numeric_detection": true,
+      "numeric_detection": false,
       "dynamic_date_formats": [
         "yyyy/MM/dd",
         "yyyy/MM/dd HH:mm:ss",


### PR DESCRIPTION
Prior to this change, the Analytics Fields Mapping was dynamically detected in ES. This change will make the Field Mapping detection made in Java Services to have a better control on field types. In fact, when a field mapping doesn't exist yet, it will be created with the explicit type switch Value Class Type.