### PR TITLE
fix: Duration in Samples Display as Milliseconds instead of Seconds - MEED-9968 - Meeds-io/meeds#3856 (#333)

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/DurationSampleItemAttribute.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/DurationSampleItemAttribute.vue
@@ -47,7 +47,7 @@ export default {
   },
   computed: {
     formattedDuration() {
-      return this.formatDuration(this.attrValue);
+      return this.formatDuration(Math.floor((this.attrValue || 0) / 1000));
     }
   },
   methods: {


### PR DESCRIPTION
Prior to this change, the analytics Duration is displayed and interpreted as seconds instead of Milliseconds.

(cherry picked from commit aa0fe7d1ebc6a4f681d631f9ab4e3133c171261f)