### PR TITLE
fix: Analytics Field Data Types Detection - MEEDS-10142 - Meeds-io/meeds#3994

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -38,6 +39,14 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StatisticData implements Serializable {
+
+  private static final List<Class<?>>     PRIMITIVE_TYPES  = List.of(Boolean.class,
+                                                                     Byte.class,
+                                                                     Short.class,
+                                                                     Integer.class,
+                                                                     Long.class,
+                                                                     Float.class,
+                                                                     Double.class);
 
   private static final long               serialVersionUID = -2660993500359866340L;
 
@@ -97,11 +106,15 @@ public class StatisticData implements Serializable {
   private Object getFieldValue(Object value) {
     if (value instanceof Date) {
       return buildDateFormat().format(value);
-    } else if (value == null || value.getClass().isPrimitive()) {
+    } else if (value == null || isOfTypePrimitiveClass(value)) {
       return value;
     } else {
       return String.valueOf(value);
     }
+  }
+
+  private static boolean isOfTypePrimitiveClass(Object value) {
+    return PRIMITIVE_TYPES.stream().anyMatch(c -> c.isAssignableFrom(value.getClass()));
   }
 
   private DateFormat buildDateFormat() {

--- a/analytics-api/src/main/java/io/meeds/analytics/model/filter/AnalyticsTableFilter.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/filter/AnalyticsTableFilter.java
@@ -78,7 +78,7 @@ public class AnalyticsTableFilter extends AbstractAnalyticsFilter {
     return null;
   }
 
-  public AnalyticsFilter buildColumnFilter(AnalyticsPeriod period,
+  public AnalyticsFilter buildColumnFilter(AnalyticsPeriod period, // NOSONAR
                                            AnalyticsPeriodType periodType,
                                            AnalyticsFieldFilter fieldFilter,
                                            int limit,

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -100,15 +101,15 @@ public class ElasticsearchAnalyticsStorage {
 
   private static final String           LONG_MAPPING_TYPE    = "long";
 
-  private static final Log              LOG                =
+  private static final Log              LOG                  =
                                             ExoLogger.getExoLogger(ElasticsearchAnalyticsStorage.class);
 
-  private static final long             DAY_IN_MS          = 86400000L;
+  private static final long             DAY_IN_MS            = 86400000L;
 
-  private static final String           DAY_DATE_FORMAT    = "yyyy-MM-dd";
+  private static final String           DAY_DATE_FORMAT      = "yyyy-MM-dd";
 
-  public static final DateTimeFormatter DAY_DATE_FORMATTER = DateTimeFormatter.ofPattern(DAY_DATE_FORMAT)
-                                                                              .withResolverStyle(ResolverStyle.LENIENT);
+  public static final DateTimeFormatter DAY_DATE_FORMATTER   = DateTimeFormatter.ofPattern(DAY_DATE_FORMAT)
+                                                                                .withResolverStyle(ResolverStyle.LENIENT);
 
   private List<String>                  ignoredFieldNames    = Collections.synchronizedList(new ArrayList<>());
 
@@ -369,13 +370,27 @@ public class ElasticsearchAnalyticsStorage {
                                            .entrySet()
                                            .stream()
                                            .filter(e -> e.getValue() != null && StringUtils.isNotBlank(e.getValue().toString()))
-                                           .filter(e -> {
+                                           .map(e -> {
                                              String name = e.getKey();
                                              Object value = e.getValue();
                                              StatisticFieldMapping mapping = mappedFields.get(name);
-                                             if (checkFieldMapping(value, mapping)) {
-                                               return true;
+                                             String altFieldName = "%s_alt".formatted(name);
+                                             if (mappedFields.containsKey(altFieldName)) {
+                                               return Pair.of(altFieldName, value);
+                                             } else if (checkFieldMapping(value, mapping)) {
+                                               return e;
+                                             } else if (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
+                                                        || mapping.getType().equals(TEXT_MAPPING_TYPE)) {
+                                               String altFieldType = createFieldMapping(altFieldName, value);
+                                               LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}'",
+                                                        name,
+                                                        altFieldName,
+                                                        mapping.getType(),
+                                                        altFieldType);
+                                               return Pair.of(altFieldName, value);
                                              } else {
+                                               // Start:: Log the same field
+                                               // only once
                                                if (!ignoredFieldNames.contains(name)) {
                                                  ignoredFieldNames.add(name);
                                                  LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
@@ -383,9 +398,12 @@ public class ElasticsearchAnalyticsStorage {
                                                           getFieldMappingType(value),
                                                           mapping.getType());
                                                }
-                                               return false;
+                                               // End:: Log the same field only
+                                               // once
+                                               return null;
                                              }
                                            })
+                                           .filter(Objects::nonNull)
                                            .collect(Collectors.toMap(Entry::getKey, e -> getFieldValue(e.getValue())));
       fields.putAll(parameters);
     }
@@ -405,23 +423,42 @@ public class ElasticsearchAnalyticsStorage {
                                                        .entrySet()
                                                        .stream()
                                                        .filter(e -> CollectionUtils.isNotEmpty(e.getValue()))
-                                                       .filter(e -> {
+                                                       .map(e -> {
                                                          Collection<Object> value = e.getValue();
                                                          String name = e.getKey();
                                                          StatisticFieldMapping mapping = mappedFields.get(name);
-                                                         if (checkFieldMapping(value, mapping)) {
-                                                           return true;
+                                                         String altFieldName = "%s_alt".formatted(name);
+                                                         if (mappedFields.containsKey(altFieldName)) {
+                                                           return Pair.of(altFieldName, value);
+                                                         } else if (checkFieldMapping(value, mapping)) {
+                                                           return e;
+                                                         } else if (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
+                                                                    || mapping.getType().equals(TEXT_MAPPING_TYPE)) {
+                                                           String altFieldType = createFieldMapping(altFieldName, value);
+                                                           LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}'",
+                                                                    name,
+                                                                    altFieldName,
+                                                                    mapping.getType(),
+                                                                    altFieldType);
+                                                           return Pair.of(altFieldName, value);
                                                          } else {
+                                                           // Start:: Log the
+                                                           // same field
+                                                           // only once
                                                            if (!ignoredFieldNames.contains(name)) {
                                                              ignoredFieldNames.add(name);
-                                                             LOG.warn("Field with name '{}' doesn't have the expected type {} in ES ('{}'). Ignore adding it in indexed document.",
+                                                             LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
                                                                       name,
                                                                       getFieldMappingType(value),
                                                                       mapping.getType());
                                                            }
-                                                           return false;
+                                                           // End:: Log the same
+                                                           // field only
+                                                           // once
+                                                           return null;
                                                          }
                                                        })
+                                                       .filter(Objects::nonNull)
                                                        .collect(Collectors.toMap(Entry::getKey,
                                                                                  e -> getFieldValue(e.getValue())));
       document.setListFields(parameters);
@@ -431,7 +468,7 @@ public class ElasticsearchAnalyticsStorage {
     return createRequest.toString() + "\n" + document.toJSON() + "\n";
   }
 
-  private void createFieldMapping(String f, Object value) {
+  private String createFieldMapping(String f, Object value) {
     String type = getFieldMappingType(value);
     try {
       sendPutRequest(elasticsearchConfiguration.getIndexAlias() + "/_mapping", String.format("""
@@ -446,11 +483,19 @@ public class ElasticsearchAnalyticsStorage {
       LOG.info("Create ES Mapping for field '{}' with type '{}'", f, type);
       listenerService.broadcast(FIELD_MAPPING_CREATED_EVENT, f, type);
     } catch (Exception e) {
-      LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists.",
-               f,
-               type,
-               e);
+      if (LOG.isDebugEnabled()) {
+        LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing.",
+                 f,
+                 type,
+                 e);
+      } else {
+        LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing. Error: {}",
+                 f,
+                 type,
+                 e.getMessage());
+      }
     }
+    return type;
   }
 
   private boolean checkFieldMapping(Object value, StatisticFieldMapping mapping) {
@@ -462,27 +507,29 @@ public class ElasticsearchAnalyticsStorage {
       if (StringUtils.equalsIgnoreCase(mappedType, fieldMappingType)) {
         return true;
       } else {
-        return switch (mappedType) {
-        case LONG_MAPPING_TYPE -> StringUtils.isNumeric(value.toString());
-        case FLOAT_MAPPING_TYPE -> LONG_MAPPING_TYPE.equals(fieldMappingType);
-        case BOOLEAN_MAPPING_TYPE -> StringUtils.equalsAny(value.toString(), "true", "false");
-        case KEYWORD_MAPPING_TYPE -> true;
-        case TEXT_MAPPING_TYPE -> true;
+        return switch (fieldMappingType) {
+        case LONG_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(mappedType) || LONG_MAPPING_TYPE.equals(mappedType);
+        case FLOAT_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(mappedType);
+        case BOOLEAN_MAPPING_TYPE -> BOOLEAN_MAPPING_TYPE.equals(mappedType);
+        case KEYWORD_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(mappedType) || TEXT_MAPPING_TYPE.equals(mappedType);
+        case TEXT_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(mappedType) || TEXT_MAPPING_TYPE.equals(mappedType);
         default -> false;
         };
       }
     }
   }
 
+  @SuppressWarnings("rawtypes")
   private String getFieldMappingType(Object value) {
     return switch (value) {
     case Integer v -> LONG_MAPPING_TYPE;
+    case Short v -> LONG_MAPPING_TYPE;
     case Long v -> LONG_MAPPING_TYPE;
     case Byte v -> LONG_MAPPING_TYPE;
     case Float v -> FLOAT_MAPPING_TYPE;
     case Double v -> FLOAT_MAPPING_TYPE;
     case Boolean v -> BOOLEAN_MAPPING_TYPE;
-    case Collection<?> v -> getFieldMappingType(v.toArray()[0]);
+    case Collection v -> getFieldMappingType(v.toArray()[0]);
     default -> KEYWORD_MAPPING_TYPE;
     };
   }
@@ -491,6 +538,7 @@ public class ElasticsearchAnalyticsStorage {
     return switch (value) {
     case Integer v -> BigDecimal.valueOf(v).toPlainString();
     case Long v -> BigDecimal.valueOf(v).toPlainString();
+    case Short v -> BigDecimal.valueOf(v).toPlainString();
     case Byte v -> BigDecimal.valueOf(v).toPlainString();
     case Float v -> BigDecimal.valueOf(v).toPlainString();
     case Double v -> BigDecimal.valueOf(v).toPlainString();

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -21,6 +21,8 @@ package io.meeds.analytics.portlet;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.portlet.*;
 import javax.ws.rs.core.MediaType;
@@ -301,6 +303,14 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
     String fromDateString = request.getParameter("min");
     String toDateString = request.getParameter("max");
     filter.addRangeFilter("timestamp", fromDateString, toDateString);
+  }
+
+  protected void convertToAltFieldName(Supplier<String> supplier, Consumer<String> consumer, Set<String> fieldNames) {
+    String fieldName = supplier.get();
+    String altFieldName = fieldName + "_alt";
+    if (fieldNames.contains(altFieldName)) {
+      consumer.accept(altFieldName);
+    }
   }
 
   protected void addScopeFilter(ResourceRequest request, AnalyticsFilter filter) throws PortletException {

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsPortlet.java
@@ -22,15 +22,24 @@ package io.meeds.analytics.portlet;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import javax.portlet.*;
+import javax.portlet.PortletException;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import io.meeds.analytics.model.StatisticData;
+import io.meeds.analytics.model.StatisticFieldMapping;
 import io.meeds.analytics.model.filter.AnalyticsFilter;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
+import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
 import io.meeds.analytics.utils.AnalyticsUtils;
 
 public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> {
@@ -47,14 +56,14 @@ public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> 
 
   @Override
   protected void readSettings(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsFilter filter = getFilterFromPreferences(request);
+    AnalyticsFilter filter = getFilter(request);
     response.setContentType(MediaType.APPLICATION_JSON);
     response.getWriter().write(AnalyticsUtils.toJsonString(filter));
   }
 
   @Override
   protected void readSettingsReadOnly(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsFilter filter = getFilterFromPreferences(request);
+    AnalyticsFilter filter = getFilter(request);
     JSONObject jsonResponse = new JSONObject();
     addJSONParam(jsonResponse, "title", filter.getTitle());
     addJSONParam(jsonResponse, "chartType", filter.getChartType());
@@ -68,7 +77,7 @@ public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> 
 
   @Override
   protected void readSamples(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsFilter filter = getFilterFromPreferences(request);
+    AnalyticsFilter filter = getFilter(request);
     addPeriodFilter(request, filter);
     addScopeFilter(request, filter);
     addLanguageFilter(request, filter);
@@ -91,7 +100,7 @@ public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> 
 
   @Override
   protected void readData(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsFilter filter = getFilterFromPreferences(request);
+    AnalyticsFilter filter = getFilter(request);
     addPeriodFilter(request, filter);
     addScopeFilter(request, filter);
     addLanguageFilter(request, filter);
@@ -100,6 +109,35 @@ public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> 
     Object result = getAnalyticsService().computeChartData(filter);
     response.setContentType(MediaType.APPLICATION_JSON);
     response.getWriter().write(AnalyticsUtils.toJsonString(result));
+  }
+
+  private AnalyticsFilter getFilter(ResourceRequest request) {
+    AnalyticsFilter filter = getFilterFromPreferences(request);
+    Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
+    Set<String> fieldNames = mappings.stream()
+                                     .map(StatisticFieldMapping::getName)
+                                     .collect(Collectors.toSet());
+
+    if (StringUtils.isNotBlank(filter.getMultipleChartsField())) {
+      convertToAltFieldName(filter::getMultipleChartsField,
+                            filter::setMultipleChartsField,
+                            fieldNames);
+    }
+    if (CollectionUtils.isNotEmpty(filter.getAggregations())) {
+      for (AnalyticsAggregation analyticsAggregation : filter.getAggregations()) {
+        convertToAltFieldName(analyticsAggregation::getField,
+                              analyticsAggregation::setField,
+                              fieldNames);
+      }
+    }
+    if (CollectionUtils.isNotEmpty(filter.getFilters())) {
+      for (AnalyticsFieldFilter analyticsFilter : filter.getFilters()) {
+        convertToAltFieldName(analyticsFilter::getField,
+                              analyticsFilter::setField,
+                              fieldNames);
+      }
+    }
+    return filter;
   }
 
 }

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
@@ -22,14 +22,22 @@ package io.meeds.analytics.portlet;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.portlet.*;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 
+import io.meeds.analytics.model.StatisticFieldMapping;
 import io.meeds.analytics.model.filter.*;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsPercentageLimit;
+import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
 import io.meeds.analytics.utils.AnalyticsUtils;
 
 public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPercentageFilter> {
@@ -45,7 +53,7 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
 
   @Override
   protected void readSettingsReadOnly(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsPercentageFilter filter = getFilterFromPreferences(request);
+    AnalyticsPercentageFilter filter = getFilter(request);
     JSONObject jsonResponse = new JSONObject();
     addJSONParam(jsonResponse, "title", filter.getTitle());
     addJSONParam(jsonResponse, "chartType", filter.getChartType());
@@ -57,14 +65,14 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
 
   @Override
   protected void readSettings(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsPercentageFilter filter = getFilterFromPreferences(request);
+    AnalyticsPercentageFilter filter = getFilter(request);
     response.setContentType(MediaType.APPLICATION_JSON);
     response.getWriter().write(AnalyticsUtils.toJsonString(filter));
   }
 
   @Override
   protected void readData(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsPercentageFilter filter = getFilterFromPreferences(request);
+    AnalyticsPercentageFilter filter = getFilter(request);
     addLanguageFilter(request, filter);
     addTimeZoneFilter(request, filter);
     addPeriodFilter(request, filter);
@@ -96,4 +104,44 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
       filter.setCustomPeriod(period);
     }
   }
+
+  private AnalyticsPercentageFilter getFilter(ResourceRequest request) {
+    AnalyticsPercentageFilter filter = getFilterFromPreferences(request);
+    Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
+    Set<String> fieldNames = mappings.stream()
+                                     .map(StatisticFieldMapping::getName)
+                                     .collect(Collectors.toSet());
+
+    convertToAltFieldName(filter.getValue(), fieldNames);
+    convertToAltFieldName(filter.getThreshold(), fieldNames);
+
+    AnalyticsPercentageLimit percentageLimit = filter.getPercentageLimit();
+    if (percentageLimit != null) {
+      convertToAltFieldName(percentageLimit::getField,
+                            percentageLimit::setField,
+                            fieldNames);
+      convertToAltFieldName(percentageLimit.getAggregation(), fieldNames);
+    }
+    return filter;
+  }
+
+  private void convertToAltFieldName(AnalyticsPercentageItemFilter valueFilter, Set<String> fieldNames) {
+    if (valueFilter != null) {
+      AnalyticsAggregation aggregation = valueFilter.getYAxisAggregation();
+      if (aggregation != null) {
+        convertToAltFieldName(aggregation::getField,
+                              aggregation::setField,
+                              fieldNames);
+      }
+      List<AnalyticsFieldFilter> filters = valueFilter.getFilters();
+      if (CollectionUtils.isNotEmpty(filters)) {
+        for (AnalyticsFieldFilter analyticsFilter : filters) {
+          convertToAltFieldName(analyticsFilter::getField,
+                                analyticsFilter::setField,
+                                fieldNames);
+        }
+      }
+    }
+  }
+
 }

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsTablePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsTablePortlet.java
@@ -20,15 +20,28 @@
 package io.meeds.analytics.portlet;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import javax.portlet.*;
+import javax.portlet.PortletException;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 
+import io.meeds.analytics.model.StatisticFieldMapping;
 import io.meeds.analytics.model.chart.TableColumnResult;
-import io.meeds.analytics.model.filter.*;
+import io.meeds.analytics.model.filter.AnalyticsFilter;
+import io.meeds.analytics.model.filter.AnalyticsPeriod;
+import io.meeds.analytics.model.filter.AnalyticsPeriodType;
+import io.meeds.analytics.model.filter.AnalyticsTableColumnAggregation;
+import io.meeds.analytics.model.filter.AnalyticsTableColumnFilter;
+import io.meeds.analytics.model.filter.AnalyticsTableFilter;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilterType;
 import io.meeds.analytics.utils.AnalyticsUtils;
@@ -47,7 +60,7 @@ public class AnalyticsTablePortlet extends AbstractAnalyticsPortlet<AnalyticsTab
 
   @Override
   protected void readSettingsReadOnly(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsTableFilter filter = getFilterFromPreferences(request);
+    AnalyticsTableFilter filter = getFilter(request);
     JSONObject jsonResponse = new JSONObject();
     addJSONParam(jsonResponse, "title", filter.getTitle());
     addJSONParam(jsonResponse, "pageSize", filter.getPageSize());
@@ -59,15 +72,15 @@ public class AnalyticsTablePortlet extends AbstractAnalyticsPortlet<AnalyticsTab
 
   @Override
   protected void readSettings(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsTableFilter filter = getFilterFromPreferences(request);
+    AnalyticsTableFilter filter = getFilter(request);
     response.setContentType("application/json");
     response.getWriter().write(AnalyticsUtils.toJsonString(filter));
   }
 
   @Override
   protected void readData(ResourceRequest request, ResourceResponse response) throws PortletException, IOException {
-    AnalyticsTableFilter tableFilter = getFilterFromPreferences(request);
-    if (tableFilter == null || tableFilter.getMainColumn() == null
+    AnalyticsTableFilter tableFilter = getFilter(request);
+    if (tableFilter.getMainColumn() == null
         || tableFilter.getMainColumn().getValueAggregation() == null
         || tableFilter.getMainColumn().getValueAggregation().getAggregation() == null
         || tableFilter.getMainColumn().getValueAggregation().getAggregation().getField() == null) {
@@ -151,4 +164,53 @@ public class AnalyticsTablePortlet extends AbstractAnalyticsPortlet<AnalyticsTab
     response.setContentType(MediaType.APPLICATION_JSON);
     response.getWriter().write(AnalyticsUtils.toJsonString(result));
   }
+
+  private AnalyticsTableFilter getFilter(ResourceRequest request) {
+    AnalyticsTableFilter filter = getFilterFromPreferences(request);
+    Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
+    Set<String> fieldNames = mappings.stream()
+                                     .map(StatisticFieldMapping::getName)
+                                     .collect(Collectors.toSet());
+    List<AnalyticsTableColumnFilter> columns = filter.getColumns();
+    for (AnalyticsTableColumnFilter analyticsTableColumnFilter : columns) {
+      convertToAltFieldName(analyticsTableColumnFilter, fieldNames);
+    }
+    convertToAltFieldName(filter.getMainColumn(), fieldNames);
+    return filter;
+  }
+
+  private void convertToAltFieldName(AnalyticsTableColumnFilter columnFilter, Set<String> fieldNames) {
+    if (columnFilter != null) {
+      convertToAltFieldName(columnFilter::getUserField,
+                            columnFilter::setUserField,
+                            fieldNames);
+      convertToAltFieldName(columnFilter::getSpaceField,
+                            columnFilter::setSpaceField,
+                            fieldNames);
+      convertToAltFieldName(columnFilter.getThresholdAggregation(),
+                            fieldNames);
+      convertToAltFieldName(columnFilter.getValueAggregation(),
+                            fieldNames);
+    }
+  }
+
+  private void convertToAltFieldName(AnalyticsTableColumnAggregation columnAggregation, Set<String> fieldNames) {
+    if (columnAggregation != null) {
+      AnalyticsAggregation aggregation = columnAggregation.getAggregation();
+      if (aggregation != null) {
+        convertToAltFieldName(aggregation::getField,
+                              aggregation::setField,
+                              fieldNames);
+      }
+      List<AnalyticsFieldFilter> filters = columnAggregation.getFilters();
+      if (CollectionUtils.isNotEmpty(filters)) {
+        for (AnalyticsFieldFilter analyticsFilter : filters) {
+          convertToAltFieldName(analyticsFilter::getField,
+                                analyticsFilter::setField,
+                                fieldNames);
+        }
+      }
+    }
+  }
+
 }

--- a/analytics-webapps/src/main/resources/locale/portlet/Analytics_en.properties
+++ b/analytics-webapps/src/main/resources/locale/portlet/Analytics_en.properties
@@ -519,3 +519,4 @@ analytics.useOfGamification=Use of gamification
 analytics.gamificationOperationTypes=Gamification - Operation types
 analytics.gamificationTopFiveUsers=Gamification - Top 5 Users
 analytics.gamificationTopFivePrograms=Gamification - Top 5 Campaigns
+analytics.field.alternative={0} (New)

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ProfilePropertyItemAttributeLabel.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ProfilePropertyItemAttributeLabel.vue
@@ -81,12 +81,16 @@ export default {
     propertyName() {
       return this.property?.split('.')?.[1];
     },
+    propertyNameKey() {
+      return this.propertyName?.replace?.('_alt', '');
+    },
     hasLabel() {
-      return this.$te(`analytics.field.label.${this.propertyName}`);
+      return this.$te(`analytics.field.label.${this.propertyNameKey}`);
     },
     propertyLabel() {
-      return this.hasLabel && this.$t(`analytics.field.label.${this.propertyName}`)
-          || this.translatedLabel
+      return this.translatedLabel
+          || (this.hasLabel && this.propertyName?.includes?.('_alt') && this.$t('analytics.field.alternative', {0: this.$t(`analytics.field.label.${this.propertyNameKey}`)}))
+          || (this.hasLabel && this.$t(`analytics.field.label.${this.propertyNameKey}`))
           || this.propertyName;
     }
   },

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItem.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItem.vue
@@ -101,8 +101,10 @@ export default {
       return this.chartData.userId || this.chartData.modifierSocialId;
     },
     operationLabel() {
-      const operationLabelI18NValue = `analytics.${this.chartData.operation}`;
-      return this.$te(operationLabelI18NValue) ? this.$t(operationLabelI18NValue) : this.chartData.operation;
+      const operationLabelI18NValue = `analytics.${this.chartData.operation?.replace?.('_alt', '')}`;
+      return this.$te(operationLabelI18NValue) ?
+        (this.chartData.operation?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(operationLabelI18NValue)}) : this.$t(operationLabelI18NValue)) // NOSONAR
+        : this.chartData.operation;
     },
   },
 };

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItemAttribute.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItemAttribute.vue
@@ -58,12 +58,16 @@ export default {
   },
   computed: {
     keyLabel() {
-      const fieldLabelI18NKey = `analytics.field.label.${this.attrKey}`;
-      return this.$te(fieldLabelI18NKey) ? this.$t(fieldLabelI18NKey) : this.attrKey;
+      const fieldLabelI18NKey = `analytics.field.label.${this.attrKey?.replace?.('_alt', '')}`;
+      return this.$te(fieldLabelI18NKey) ?
+        (this.attrKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey)) // NOSONAR
+        : this.attrKey;
     },
     valueLabel() {
-      const fieldLabelI18NValue = `analytics.${this.attrValue}`;
-      return this.$te(fieldLabelI18NValue) ? this.$t(fieldLabelI18NValue) : this.attrValue;
+      const fieldLabelI18NValue = `analytics.${this.attrValue?.replace?.('_alt', '')}`;
+      return this.$te(fieldLabelI18NValue) ?
+        (this.attrValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NValue)}) : this.$t(fieldLabelI18NValue)) // NOSONAR
+        : this.attrValue;
     },
     sampleItemExtension() {
       if (this.sampleItemExtensions) {

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/FieldSelection.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/FieldSelection.vue
@@ -127,8 +127,8 @@ export default {
         if (!fieldMapping.label) {
           const label = fieldMapping.name;
           const labelPart = label.indexOf('.') >= 0 ? label.substring(label.lastIndexOf('.') + 1) : label;
-          const fieldLabelI18NKey = `analytics.field.label.${labelPart}`;
-          const fieldLabelI18NValue = this.$t(fieldLabelI18NKey);
+          const fieldLabelI18NKey = `analytics.field.label.${labelPart?.replace?.('_alt', '')}`;
+          const fieldLabelI18NValue = labelPart?.includes?.('_alt') && this.$te(fieldLabelI18NKey) ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey);
           fieldMapping.label = fieldLabelI18NValue === fieldLabelI18NKey ? `${this.$t('analytics.field.label.default')} ${label}` : fieldLabelI18NValue;
         }
       });

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/TextValuesFilter.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/TextValuesFilter.vue
@@ -107,8 +107,10 @@ export default {
       if (this.isProfilePropertyOption) {
         return await this.getProfilePropertyOptionTranslation(value);
       }
-      const key = `analytics.${value}`;
-      return this.$te(key) ? this.$t(key) : value;
+      const key = `analytics.${value?.replace?.('_alt', '')}`;
+      return this.$te(key) ?
+        (value?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(key)}) : this.$t(key)) // NOSONAR
+        : value;
     },
     selectValue(value) {
       if (this.multipleOperator) {

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
@@ -235,8 +235,16 @@ export default {
         if (extension) {
           return extension.getLabel(fieldName, fieldValue);
         } else {
-          const fieldLabelI18NKey = `analytics.${fieldValue}`;
-          return this.$te(fieldLabelI18NKey) ? this.$t(fieldLabelI18NKey) : label;
+          let fieldLabelI18NKey = `analytics.${fieldValue?.replace?.('_alt', '')}`;
+          if (this.$te(fieldLabelI18NKey)) {
+            return fieldValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey);
+          } else {
+            fieldLabelI18NKey = `analytics.field.label.${fieldValue?.replace?.('_alt', '')}`;
+            return this.$te(fieldLabelI18NKey) ?
+              (fieldValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey)) // NOSONAR
+              : label;
+          }
+          
         }
       } else {
         return label;

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetList.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetList.vue
@@ -22,7 +22,7 @@
 <template>
   <v-list v-if="hasSpaces" class="pa-0">
     <div v-if="labelKey" class="d-flex text-body align-center justify-center px-0">
-      <span class="pe-2">{{ $t(labelKey) }}</span>
+      <span class="pe-2">{{ label }}</span>
       <v-divider class="flex-grow-1" />
     </div>
     <spaces-list-widget-item
@@ -44,6 +44,9 @@ export default {
     },
   },
   computed: {
+    label() {
+      return this.labelKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(this.labelKey?.replace?.('_alt', ''))}) : this.$t(this.labelKey);
+    },
     hasSpaces() {
       return this.list?.length;
     },

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/settings/AnalyticsTableColumnSetting.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/settings/AnalyticsTableColumnSetting.vue
@@ -122,7 +122,7 @@ export default {
   }),
   computed: {
     columnTitle() {
-      return this.column && this.column.title;
+      return this.column && this.column.title?.replace?.('_alt', '');
     },
     canEnableIdentityFields() {
       return this.useUserField || this.useSpaceField;

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -206,7 +206,7 @@ export default {
     },
     addHeader(headers, column, index) {
       headers.push({
-        text: column.title && this.$t(column.title) || '',
+        text: column.title && this.$t(column.title?.replace?.('_alt', '')) || '',
         align: column.align || 'center',
         sortable: column.sortable,
         value: `column${index}`,

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellValue.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellValue.vue
@@ -152,9 +152,10 @@ export default {
   }),
   computed: {
     i18NValue() {
-      const key = `analytics.${this.value}`;
-      const i18NValue = this.$t(key);
-      return i18NValue === key ? this.value : i18NValue;
+      const key = `analytics.${this.value?.replace?.('_alt', '')}`;
+      return this.$te(key) ?
+        (this.value?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(key)}) : this.$t(key)) // NOSONAR
+        : this.value;
     },
     isNumeric() {
       return (this.dataType === 'long' || this.dataType === 'double')


### PR DESCRIPTION
Prior to this change, when adding a StatisticData parameter, the field type is sometimes not well detected and rathen than using a Long it still uses a String. This change ensures to align Field Mapping Creation Request with Field Check Request. In addition, this change will allow to distinguish the new fields from the old fields by a suffix (New).

Resolves Meeds-io/meeds#3994