### PR TITLE
fix: Display the header of the space list portlet even when there are no spaces - MEED-10165 - Meeds-io/meeds#4018

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
@@ -27,14 +27,12 @@
         extra-class="application-body fill-height">
         <template #title>
           <div class="d-flex flex-grow-1 flex-shrink-1 full-width align-center position-relative">
-            <div
-              v-if="!emptyWidget"
-              class="widget-text-header text-none text-truncate d-flex align-center">
+            <div class="widget-text-header text-none text-truncate d-flex align-center">
               {{ title }}
             </div>
             <div
               :class="{
-                'mt-2 me-2': emptyWidget,
+                'me-2': emptyWidget,
                 'l-0': $vuetify.rtl,
                 'r-0': !$vuetify.rtl,
               }"


### PR DESCRIPTION
This change will display the header of the space list portlet even when there are no spaces.

Resolves: Meeds-io/meeds#4018