### PR TITLE
fix: Update the space list widget to use the alternative field - MEED-10279 - Meeds-io/meeds#4080

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -33,6 +33,8 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
 import java.time.temporal.IsoFields;
 import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.time.LocalDate;
@@ -503,6 +505,14 @@ public class AnalyticsUtils {
       if (space != null) {
         addSpaceStatistics(statisticData, space);
       }
+    }
+  }
+
+  public static void convertToAltFieldName(Supplier<String> supplier, Consumer<String> consumer, Set<String> fieldNames) {
+    String fieldName = supplier.get();
+    String altFieldName = fieldName + "_alt";
+    if (fieldNames.contains(altFieldName)) {
+      consumer.accept(altFieldName);
     }
   }
 

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -21,8 +21,6 @@ package io.meeds.analytics.portlet;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import javax.portlet.*;
 import javax.ws.rs.core.MediaType;
@@ -303,14 +301,6 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
     String fromDateString = request.getParameter("min");
     String toDateString = request.getParameter("max");
     filter.addRangeFilter("timestamp", fromDateString, toDateString);
-  }
-
-  protected void convertToAltFieldName(Supplier<String> supplier, Consumer<String> consumer, Set<String> fieldNames) {
-    String fieldName = supplier.get();
-    String altFieldName = fieldName + "_alt";
-    if (fieldNames.contains(altFieldName)) {
-      consumer.accept(altFieldName);
-    }
   }
 
   protected void addScopeFilter(ResourceRequest request, AnalyticsFilter filter) throws PortletException {

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsPortlet.java
@@ -42,6 +42,8 @@ import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
 import io.meeds.analytics.utils.AnalyticsUtils;
 
+import static io.meeds.analytics.utils.AnalyticsUtils.convertToAltFieldName;
+
 public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> {
 
   @Override

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
@@ -23,14 +23,19 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import javax.portlet.PortletException;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 
+import io.meeds.analytics.model.StatisticFieldMapping;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilterType;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.javascript.jscomp.jarjar.com.google.re2j.Pattern;
@@ -44,6 +49,8 @@ import io.meeds.analytics.api.service.AnalyticsService;
 import io.meeds.analytics.model.chart.ChartDataList;
 import io.meeds.analytics.model.filter.AnalyticsFilter;
 import io.meeds.analytics.utils.AnalyticsUtils;
+
+import static io.meeds.analytics.utils.AnalyticsUtils.convertToAltFieldName;
 
 public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
 
@@ -89,7 +96,7 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
     response.setContentType("application/json");
   }
 
-  private AnalyticsFilter getFilter(ResourceRequest request) throws IllegalAccessException {
+  private AnalyticsFilter getFilterFromRequest(ResourceRequest request) throws IllegalAccessException {
     String filterName = request.getParameter("queryName");
     String filterString = getFilterContent(filterName);
     if (filterString.contains("{userIdentityId}")) {
@@ -124,6 +131,28 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
       filterString = filterString.replace(TO_TIMESTAMP_PARAM, toTimestamp);
     }
     return AnalyticsUtils.fromJsonString(filterString, AnalyticsFilter.class);
+  }
+
+  private AnalyticsFilter getFilter(ResourceRequest request) throws IllegalAccessException {
+    AnalyticsFilter filter = getFilterFromRequest(request);
+    applyParentSpaceFilter(request, filter);
+    Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
+    Set<String> fieldNames = mappings.stream().map(StatisticFieldMapping::getName).collect(Collectors.toSet());
+    if (CollectionUtils.isNotEmpty(filter.getAggregations())) {
+      for (AnalyticsAggregation analyticsAggregation : filter.getAggregations()) {
+        convertToAltFieldName(analyticsAggregation::getField,
+                              analyticsAggregation::setField,
+                              fieldNames);
+      }
+    }
+    if (CollectionUtils.isNotEmpty(filter.getFilters())) {
+      for (AnalyticsFieldFilter analyticsFilter : filter.getFilters()) {
+        convertToAltFieldName(analyticsFilter::getField,
+                              analyticsFilter::setField,
+                              fieldNames);
+      }
+    }
+    return filter;
   }
 
   private String getFilterContent(String filterName) {

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
@@ -117,7 +117,7 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
 
     AnalyticsPercentageLimit percentageLimit = filter.getPercentageLimit();
     if (percentageLimit != null) {
-      convertToAltFieldName(percentageLimit::getField,
+      AnalyticsUtils.convertToAltFieldName(percentageLimit::getField,
                             percentageLimit::setField,
                             fieldNames);
       convertToAltFieldName(percentageLimit.getAggregation(), fieldNames);
@@ -129,16 +129,16 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
     if (valueFilter != null) {
       AnalyticsAggregation aggregation = valueFilter.getYAxisAggregation();
       if (aggregation != null) {
-        convertToAltFieldName(aggregation::getField,
-                              aggregation::setField,
-                              fieldNames);
+        AnalyticsUtils.convertToAltFieldName(aggregation::getField,
+                                             aggregation::setField,
+                                             fieldNames);
       }
       List<AnalyticsFieldFilter> filters = valueFilter.getFilters();
       if (CollectionUtils.isNotEmpty(filters)) {
         for (AnalyticsFieldFilter analyticsFilter : filters) {
-          convertToAltFieldName(analyticsFilter::getField,
-                                analyticsFilter::setField,
-                                fieldNames);
+          AnalyticsUtils.convertToAltFieldName(analyticsFilter::getField,
+                                               analyticsFilter::setField,
+                                               fieldNames);
         }
       }
     }

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsTablePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsTablePortlet.java
@@ -181,12 +181,12 @@ public class AnalyticsTablePortlet extends AbstractAnalyticsPortlet<AnalyticsTab
 
   private void convertToAltFieldName(AnalyticsTableColumnFilter columnFilter, Set<String> fieldNames) {
     if (columnFilter != null) {
-      convertToAltFieldName(columnFilter::getUserField,
-                            columnFilter::setUserField,
-                            fieldNames);
-      convertToAltFieldName(columnFilter::getSpaceField,
-                            columnFilter::setSpaceField,
-                            fieldNames);
+      AnalyticsUtils.convertToAltFieldName(columnFilter::getUserField,
+                                           columnFilter::setUserField,
+                                           fieldNames);
+      AnalyticsUtils.convertToAltFieldName(columnFilter::getSpaceField,
+                                           columnFilter::setSpaceField,
+                                           fieldNames);
       convertToAltFieldName(columnFilter.getThresholdAggregation(),
                             fieldNames);
       convertToAltFieldName(columnFilter.getValueAggregation(),
@@ -198,16 +198,16 @@ public class AnalyticsTablePortlet extends AbstractAnalyticsPortlet<AnalyticsTab
     if (columnAggregation != null) {
       AnalyticsAggregation aggregation = columnAggregation.getAggregation();
       if (aggregation != null) {
-        convertToAltFieldName(aggregation::getField,
-                              aggregation::setField,
-                              fieldNames);
+        AnalyticsUtils.convertToAltFieldName(aggregation::getField,
+                                             aggregation::setField,
+                                             fieldNames);
       }
       List<AnalyticsFieldFilter> filters = columnAggregation.getFilters();
       if (CollectionUtils.isNotEmpty(filters)) {
         for (AnalyticsFieldFilter analyticsFilter : filters) {
-          convertToAltFieldName(analyticsFilter::getField,
-                                analyticsFilter::setField,
-                                fieldNames);
+          AnalyticsUtils.convertToAltFieldName(analyticsFilter::getField,
+                                               analyticsFilter::setField,
+                                               fieldNames);
         }
       }
     }


### PR DESCRIPTION
Prior to this change, the Space List widget failed to display the most active subspaces. The issue was caused by the AnalyticsQuery portlet using the deprecated `parentSpaceId` field, which has been replaced by the alternative `parentSpaceId_alt` field. This update ensures that the portlet uses the alternative field when available, aligning it with the new field upgrade strategy