### PR TITLE
feat: Compute the number of views for activities - MEED-10146 - Meeds-io/MIPs#239

### DIFF
--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
@@ -25,7 +25,13 @@ import static io.meeds.analytics.utils.AnalyticsUtils.addStatisticData;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -58,6 +64,12 @@ public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNoti
   @Autowired
   private ListenerService           listenerService;
 
+  @Autowired
+  private ActivityManager           activityManager;
+
+  @Autowired
+  private MetadataService           metadataService;
+
   @PostConstruct
   public void init() {
     EVENT_NAMES.forEach(name -> listenerService.addListener(name, this));
@@ -74,6 +86,15 @@ public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNoti
       statisticData = buildStatisticData("markAsRead",
                                          spaceWebNotificationItem.getSpaceId(),
                                          spaceWebNotificationItem.getUserId());
+
+      ExoSocialActivity activity = activityManager.getActivity(spaceWebNotificationItem.getActivityId());
+      MetadataKey viewersMetadataKey = new MetadataKey("viewers", activity.getUserId(), Long.parseLong(activity.getUserId()));
+      List<MetadataItem> viewersMetadataItems = metadataService.getMetadataItemsByMetadataAndObject(viewersMetadataKey, activity.getMetadataObject());
+      if (CollectionUtils.isNotEmpty(viewersMetadataItems)) {
+        for (MetadataItem viewersMetadataItem : viewersMetadataItems) {
+          metadataService.deleteMetadataItem(viewersMetadataItem.getId(), true);
+        }
+      }
       break;
     case SpaceWebNotificationService.NOTIFICATION_UNREAD_EVENT_NAME:
       statisticData = buildStatisticData("markAsUnRead",

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
@@ -27,11 +27,15 @@ import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.metadata.MetadataService;
 import org.exoplatform.social.metadata.model.MetadataItem;
 import org.exoplatform.social.metadata.model.MetadataKey;
+import org.exoplatform.social.metadata.model.MetadataType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -54,9 +58,15 @@ import jakarta.annotation.PostConstruct;
 @Component
 public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNotificationItem, Long> {
 
-  private static final List<String> EVENT_NAMES = Arrays.asList("notification.read.item",
-                                                                "notification.unread.item",
-                                                                "notification.read.allItems");
+  private static final Log          LOG           = ExoLogger.getLogger(AnalyticsSpaceWebNotificationListener.class);
+
+  private static final List<String> EVENT_NAMES   = Arrays.asList("notification.read.item",
+                                                                  "notification.unread.item",
+                                                                  "notification.read.allItems");
+
+  private static final String       METADATA_NAME = "viewers";
+
+  public static final MetadataType  METADATA_TYPE = new MetadataType(METADATA_NAME.hashCode(), METADATA_NAME);
 
   @Autowired
   private SpaceService              spaceService;
@@ -86,15 +96,7 @@ public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNoti
       statisticData = buildStatisticData("markAsRead",
                                          spaceWebNotificationItem.getSpaceId(),
                                          spaceWebNotificationItem.getUserId());
-
-      ExoSocialActivity activity = activityManager.getActivity(spaceWebNotificationItem.getActivityId());
-      MetadataKey viewersMetadataKey = new MetadataKey("viewers", activity.getUserId(), Long.parseLong(activity.getUserId()));
-      List<MetadataItem> viewersMetadataItems = metadataService.getMetadataItemsByMetadataAndObject(viewersMetadataKey, activity.getMetadataObject());
-      if (CollectionUtils.isNotEmpty(viewersMetadataItems)) {
-        for (MetadataItem viewersMetadataItem : viewersMetadataItems) {
-          metadataService.deleteMetadataItem(viewersMetadataItem.getId(), true);
-        }
-      }
+      deleteViewersMetadata(spaceWebNotificationItem.getApplicationItemId());
       break;
     case SpaceWebNotificationService.NOTIFICATION_UNREAD_EVENT_NAME:
       statisticData = buildStatisticData("markAsUnRead",
@@ -138,5 +140,20 @@ public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNoti
     statisticData.setUserId(userId);
     addSpaceStatistics(statisticData, space);
     return statisticData;
+  }
+
+  private void deleteViewersMetadata(String activityId) {
+    ExoSocialActivity activity = activityManager.getActivity(activityId);
+    MetadataKey viewersMetadataKey = new MetadataKey(METADATA_TYPE.getName(), METADATA_NAME, Long.parseLong(activity.getUserId()));
+    List<MetadataItem> viewersMetadataItems = metadataService.getMetadataItemsByMetadataAndObject(viewersMetadataKey, activity.getMetadataObject());
+    if (CollectionUtils.isNotEmpty(viewersMetadataItems)) {
+      for (MetadataItem viewersMetadataItem : viewersMetadataItems) {
+        try {
+          metadataService.deleteMetadataItem(viewersMetadataItem.getId(), true);
+        } catch (ObjectNotFoundException e) {
+          LOG.debug("Unable to delete viewers metadata for activity {}", activityId, e);
+        }
+      }
+    }
   }
 }

--- a/analytics-services/src/main/java/io/meeds/analytics/activity/processor/ActivityViewersProcessor.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/activity/processor/ActivityViewersProcessor.java
@@ -1,8 +1,30 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package io.meeds.analytics.activity.processor;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.meeds.analytics.api.service.AnalyticsService;
-import io.meeds.analytics.model.StatisticData;
+import io.meeds.analytics.model.chart.ChartDataList;
 import io.meeds.analytics.model.filter.AnalyticsFilter;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.collections4.CollectionUtils;
 import org.exoplatform.commons.ObjectAlreadyExistsException;
@@ -20,7 +42,9 @@ import org.exoplatform.social.metadata.model.MetadataType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component
 public class ActivityViewersProcessor extends BaseActivityProcessorPlugin {
@@ -43,22 +67,21 @@ public class ActivityViewersProcessor extends BaseActivityProcessorPlugin {
   private AnalyticsService         analyticsService;
 
   public ActivityViewersProcessor() {
-        super(initParams());
-    }
+    super(initParams());
+  }
 
   @Override
   public String getName() {
-        return ACTIVITY_PROCESSOR_NAME;
-    }
+    return ACTIVITY_PROCESSOR_NAME;
+  }
 
   @PostConstruct
   public void init() {
-        activityManager.addProcessor(this);
-    }
+    activityManager.addProcessor(this);
+  }
 
   @Override
   public void processActivity(ExoSocialActivity activity) {
-
     String authorId = activity.getUserId();
     MetadataKey metadataKey = new MetadataKey(METADATA_TYPE.getName(), METADATA_NAME, Long.parseLong(authorId));
     List<MetadataItem> viewersIdentityIds = metadataService.getMetadataItemsByMetadataAndObject(metadataKey, activity.getMetadataObject());
@@ -68,16 +91,30 @@ public class ActivityViewersProcessor extends BaseActivityProcessorPlugin {
       filter.addEqualFilter("entityType", "activity");
       filter.addEqualFilter("entityId", activity.getId());
       filter.addEqualFilter("event-type", "read");
-      List<StatisticData> stats = analyticsService.retrieveData(filter);
-      for (StatisticData stat : stats) {
-        long viewerId = stat.getUserId();
-        if (String.valueOf(viewerId).equals(authorId)) {
-          continue;
-        }
+      AnalyticsAggregation userAgg = new AnalyticsAggregation("userId");
+      filter.addXAxisAggregation(userAgg);
+
+      ChartDataList chartData = analyticsService.computeChartData(filter);
+
+      List<Long> viewerIds = chartData.getAggregationLabels().stream()
+                                                             .flatMap(label -> label.getAggregationValues().stream())
+                                                             .map(value -> Long.parseLong(value.getFieldValue()))
+                                                             .filter(viewerId -> !String.valueOf(viewerId).equals(authorId))
+                                                             .toList();
+      if (CollectionUtils.isNotEmpty(viewerIds)) {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonIds = null;
         try {
-          metadataService.createMetadataItem(activity.getMetadataObject(), metadataKey, viewerId);
+          jsonIds = mapper.writeValueAsString(viewerIds);
+        } catch (JsonProcessingException e) {
+          throw new RuntimeException(e);
+        }
+        Map<String, String> properties = new HashMap<>();
+        properties.put("viewerIds", jsonIds);
+        try {
+          metadataService.createMetadataItem(activity.getMetadataObject(), metadataKey, properties);
         } catch (ObjectAlreadyExistsException e) {
-          LOG.warn("Metadata already exists for viewer {} on activity {}", viewerId, activity.getId(), e);
+          LOG.warn("Viewers metadata already exists for activity {}", activity.getId(), e);
         }
       }
     }

--- a/analytics-services/src/main/java/io/meeds/analytics/activity/processor/ActivityViewersProcessor.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/activity/processor/ActivityViewersProcessor.java
@@ -1,0 +1,94 @@
+package io.meeds.analytics.activity.processor;
+
+import io.meeds.analytics.api.service.AnalyticsService;
+import io.meeds.analytics.model.StatisticData;
+import io.meeds.analytics.model.filter.AnalyticsFilter;
+import jakarta.annotation.PostConstruct;
+import org.apache.commons.collections4.CollectionUtils;
+import org.exoplatform.commons.ObjectAlreadyExistsException;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.BaseActivityProcessorPlugin;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
+import org.exoplatform.social.metadata.MetadataService;
+import org.exoplatform.social.metadata.model.MetadataItem;
+import org.exoplatform.social.metadata.model.MetadataKey;
+import org.exoplatform.social.metadata.model.MetadataType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ActivityViewersProcessor extends BaseActivityProcessorPlugin {
+
+  private static final Log         LOG                     = ExoLogger.getLogger(ActivityViewersProcessor.class);
+
+  private static final String      ACTIVITY_PROCESSOR_NAME = "ActivityViewersProcessor";
+
+  private static final String      METADATA_NAME           = "viewers";
+
+  public static final MetadataType METADATA_TYPE           = new MetadataType(METADATA_NAME.hashCode(), METADATA_NAME);
+
+  @Autowired
+  private MetadataService          metadataService;
+
+  @Autowired
+  private ActivityManager          activityManager;
+
+  @Autowired
+  private AnalyticsService         analyticsService;
+
+  public ActivityViewersProcessor() {
+        super(initParams());
+    }
+
+  @Override
+  public String getName() {
+        return ACTIVITY_PROCESSOR_NAME;
+    }
+
+  @PostConstruct
+  public void init() {
+        activityManager.addProcessor(this);
+    }
+
+  @Override
+  public void processActivity(ExoSocialActivity activity) {
+
+    String authorId = activity.getUserId();
+    MetadataKey metadataKey = new MetadataKey(METADATA_TYPE.getName(), METADATA_NAME, Long.parseLong(authorId));
+    List<MetadataItem> viewersIdentityIds = metadataService.getMetadataItemsByMetadataAndObject(metadataKey, activity.getMetadataObject());
+    if (CollectionUtils.isEmpty(viewersIdentityIds)) {
+      AnalyticsFilter filter = new AnalyticsFilter();
+      filter.addEqualFilter("operation", "markAsRead");
+      filter.addEqualFilter("entityType", "activity");
+      filter.addEqualFilter("entityId", activity.getId());
+      filter.addEqualFilter("event-type", "read");
+      List<StatisticData> stats = analyticsService.retrieveData(filter);
+      for (StatisticData stat : stats) {
+        long viewerId = stat.getUserId();
+        if (String.valueOf(viewerId).equals(authorId)) {
+          continue;
+        }
+        try {
+          metadataService.createMetadataItem(activity.getMetadataObject(), metadataKey, viewerId);
+        } catch (ObjectAlreadyExistsException e) {
+          LOG.warn("Metadata already exists for viewer {} on activity {}", viewerId, activity.getId(), e);
+        }
+      }
+    }
+  }
+
+  private static InitParams initParams() {
+    InitParams initParams = new InitParams();
+    ValueParam param = new ValueParam();
+    param.setName("priority");
+    param.setValue("20");
+    initParams.addParameter(param);
+    return initParams;
+  }
+}


### PR DESCRIPTION
This change will add a processor for activity to compute the list of identity ids from analytics data if they are not available in metadata.