### PR TITLE
fix: date difference calculated wrongly - MEED-10214

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/common/SelectPeriod.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/common/SelectPeriod.vue
@@ -320,8 +320,10 @@ export default {
           this.dates[0] = this.dates[1];
           this.dates[1] = value;
         }
-        selectedPeriod.min = new Date(`${this.dates[0]}T${this.fromTime || '00:00'}`).getTime();
-        selectedPeriod.max = new Date(`${this.dates[1]}T${this.toTime || '23:59'}`).getTime();
+        const startDate = this.dates[0].split('-');
+        const endDate = this.dates[1].split('-');
+        selectedPeriod.min = Date.UTC(startDate[0], startDate[1] - 1, startDate[2], 0, 0, 0);
+        selectedPeriod.max = Date.UTC(endDate[0], endDate[1] - 1 , endDate[2], 23, 59, 59);
         this.$emit('input', selectedPeriod);
         return true;
       }

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -291,7 +291,7 @@ export default {
           limit: String(limit || 0),
           periodType: this.period.period || '',
           min: this.period.min,
-          max: this.period.max + 60000,
+          max: this.period.max + 1000,
           timeZone: this.$analyticsUtils.USER_TIMEZONE_ID,
         };
         if (sort) {


### PR DESCRIPTION
When selecting two dates on the date selector, the difference between those dates calculates the number of full days between them Thus a missing millisecond will result in a whole day removed. This caused that results retrieved from ES is paginated with the wrong interval of days which lead to having wrong results for the current selected date (almost it returns null for all of them) The fix forces using the UTC timezone as it is the one used in ES, and it adds the missing millisecond to split correctly the period of returned analytics
