### PR TITLE
fix: incorrect styling of the create space CTA in the Space List - MEED-10367 - Meeds-io/meeds#4174

### DIFF
--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
@@ -76,7 +76,6 @@
                 v-if="$root.canCreateSpace"
                 :color="'primary'"
                 :elevation="0"
-                :display-icon="false"
                 outlined
                 require-form-drawer
                 display-label />


### PR DESCRIPTION
This change fixes the CTA styling to ensure it is consistently displayed as an outlined button with a “+” icon and “Add” label