### PR TITLE
fix: Suggest subspace creation when space list widget is in a parent space - MEED-10368 - Meeds-io/meeds#4175

### DIFF
--- a/analytics-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/analytics-webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -213,6 +213,9 @@
       <depends>
         <module>translationField</module>
       </depends>
+      <depends>
+        <module>spacesListComponents</module>
+      </depends>
     </module>
   </portlet>
 

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidget.vue
@@ -76,6 +76,7 @@
                 v-if="$root.canCreateSpace"
                 :color="'primary'"
                 :elevation="0"
+                :parent-space-id="$root.isParentSpace && spaceId || null"
                 outlined
                 require-form-drawer
                 display-label />
@@ -147,11 +148,11 @@ export default {
     listOnlySubSpaces() {
       return this.$root.listOnlySubSpaces;
     },
-    parentSpaceId() {
+    spaceId() {
       return this.$root.spaceId;
     },
     appendParentSpaceParam() {
-      return !!(this.listOnlySubSpaces && this.parentSpaceId);
+      return !!(this.listOnlySubSpaces && this.spaceId);
     },
 
   },
@@ -217,7 +218,7 @@ export default {
         limit: this.$root.userSpacesLimit,
         filter: 'member',
         expand: 'spaceId',
-        parentSpaceId: this.appendParentSpaceParam && this.parentSpaceId || null
+        parentSpaceId: this.appendParentSpaceParam && this.spaceId || null
       })
         .then(data => this.$root.spaceIds = data?.spaces?.map(s => s.id) || []);
     },
@@ -243,7 +244,7 @@ export default {
       }
       let fetchUrl = `${this.$root.resourceURL}&queryName=${queryName}&xLimit=${limit}&fromTimestamp=${this.getPeriodTimestamp(period)}`;
       if (this.appendParentSpaceParam) {
-        fetchUrl = `${fetchUrl}&parentSpaceId=${this.parentSpaceId}`;
+        fetchUrl = `${fetchUrl}&parentSpaceId=${this.spaceId}`;
       }
       return fetch(fetchUrl)
         .then(resp => resp?.ok && resp.json());

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetDrawer.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetDrawer.vue
@@ -32,11 +32,12 @@
         <span> {{ memberSpacesOnly && $t('analytics.spacesListWidget.tab.userSpaces') || $t('analytics.spacesListWidget.drawer.title') }} </span>
         <space-creation-button
           v-if="$root.canCreateSpace"
+          require-form-drawer
+          display-label
           :color="'primary'"
           :elevation="0"
-          :display-icon="false"
-          require-form-drawer
-          display-label />
+          :parent-space-id="$root.isParentSpace && $root.spaceId || null"
+          :display-icon="false" />
       </div>
     </template>
     <template v-if="drawer" #content>

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/main.js
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/main.js
@@ -60,21 +60,27 @@ export function init(
           headerTranslations: headerTranslations,
           defaultLanguage: eXo?.env?.portal?.defaultLanguage,
           spaceId: eXo?.env?.portal?.spaceId,
-          listOnlySubSpaces: listOnlySubSpaces
+          listOnlySubSpaces: listOnlySubSpaces,
+          isParentSpace: false,
         },
         computed: {
           headerTitle() {
             return this.headerTranslations?.[lang] || this.headerTranslations?.[this.defaultLanguage];
           }
         },
-        created() {
+        async created() {
           if (Object.keys(this.headerTranslations).length === 0) {
             this.headerTranslations = {[this.defaultLanguage]: this.$t('analytics.spacesListWidget.header')};
+          }
+          if (this.spaceId) {
+            const space = await this.$spaceService.getSpaceById(this.spaceId);
+            this.isParentSpace = !!space?.isParentSpace;
           }
         },
         template: `<spaces-list-widget id="${appId}" />`,
         i18n,
         vuetify: Vue.prototype.vuetifyOptions,
       }, `#${appId}`, 'Space List Widget');
-    }).finally(() => Vue.prototype?.$utils?.includeExtensions('SpaceListExtension'));
+    });
 }
+


### PR DESCRIPTION
Prior to this change, when the space list widget was added to a parent space layout, users could create either a main space or a subspace. This update restricts the behavior to suggest only subspace creation when the portlet is used within a parent space. It also properly adds the space creation button to the portlet so that it is displayed when editing the layout