### PR TITLE
fix: Fix the last activity label in spaces administration page - EXO-87291

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -75,5 +75,15 @@ files: [
     "escape_special_characters": 0,
     "escape_quotes": 0,
   },
+  {
+    "source": "/analytics-webapps/src/main/resources/locale/portlet/social/SpacesAdministrationPortlet_en.properties",
+
+    "translation": "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace": { YML_CROWDIN_LANGUAGES_ARG },
+    "dest": "hub/analytics/SpacesAdministrationPortlet.properties",
+    "update_option": "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes": 0,
+  },
 
 ]


### PR DESCRIPTION
This change will fix the last activity label in spaces administration page by adding the SpacesAdministrationPortlet localization file to the Crowdin synchronization configuration.
