### PR TITLE
fix: Add auth-server Spring Profile on OAuth Listeners

### DIFF
--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientListener.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.stereotype.Component;
 
@@ -54,6 +55,7 @@ import io.meeds.analytics.model.StatisticData;
 import jakarta.annotation.PostConstruct;
 
 @Component
+@Profile("auth-server")
 public class OAuthClientListener implements ListenerBase<String, RegisteredClient> {
 
   private static final List<String> EVENT_TYPES = Arrays.asList(CLIENT_CREATED_EVENT,

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientRegisterErrorListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientRegisterErrorListener.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.authorization.oidc.OidcClientRegistration;
 import org.springframework.stereotype.Component;
 
@@ -48,6 +49,7 @@ import io.meeds.oauth2.server.model.OAuthCimdClientMetadata;
 import jakarta.annotation.PostConstruct;
 
 @Component
+@Profile("auth-server")
 public class OAuthClientRegisterErrorListener implements ListenerBase<Object, RuntimeException> {
 
   private static final List<String> EVENT_TYPES = Arrays.asList(CLIENT_REGISTER_REJECT_EVENT);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentConsumerListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentConsumerListener.java
@@ -28,6 +28,7 @@ import static io.meeds.analytics.utils.AnalyticsUtils.addStatisticData;
 import static io.meeds.oauth2.server.util.OAuthEventType.CONSENT_USED;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.stereotype.Component;
@@ -47,6 +48,7 @@ import jakarta.annotation.PostConstruct;
 
 @Component
 @Asynchronous
+@Profile("auth-server")
 public class OAuthConsentConsumerListener implements ListenerBase<OAuth2AuthorizationConsent, String> {
 
   @Autowired

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentListener.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.stereotype.Component;
@@ -55,6 +56,7 @@ import jakarta.annotation.PostConstruct;
 
 @Component
 @Asynchronous
+@Profile("auth-server")
 public class OAuthConsentListener implements ListenerBase<OAuth2AuthorizationConsent, OAuth2AuthorizationConsent> {
 
   private static final List<String> EVENT_TYPES = Arrays.asList(CONSENT_CREATED,

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenConsumerListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenConsumerListener.java
@@ -29,6 +29,7 @@ import static io.meeds.analytics.utils.AnalyticsUtils.addStatisticData;
 import static io.meeds.oauth2.server.util.OAuthEventType.TOKEN_USED;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.stereotype.Component;
@@ -48,6 +49,7 @@ import jakarta.annotation.PostConstruct;
 
 @Component
 @Asynchronous
+@Profile("auth-server")
 public class OAuthTokenConsumerListener implements ListenerBase<OAuth2Authorization, String> {
 
   @Autowired

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenListener.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.stereotype.Component;
@@ -55,6 +56,7 @@ import jakarta.annotation.PostConstruct;
 
 @Component
 @Asynchronous
+@Profile("auth-server")
 public class OAuthTokenListener implements ListenerBase<OAuth2Authorization, OAuth2Authorization> {
 
   private static final List<String> EVENT_TYPES = Arrays.asList(TOKEN_CREATED,


### PR DESCRIPTION
Prior to this change, when the AUTH-Server addon isn't installed, the server can't be started. This change ensures to not make the auth-server addon remain not mandatory for server startup.