### PR TITLE
fix: Avoid NPE when computing Activity Viewers - EXO-87629

### DIFF
--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsViewListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsViewListener.java
@@ -19,9 +19,8 @@
  */
 package io.meeds.analytics.listener.social;
 
-import java.util.*;
+import java.util.List;
 
-import io.meeds.analytics.plugin.ActivityViewProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -30,7 +29,10 @@ import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.social.notification.model.SpaceWebNotificationItem;
+
+import io.meeds.analytics.plugin.ActivityViewProcessor;
 import io.meeds.common.ContainerTransactional;
+import io.meeds.social.activity.plugin.ActivityContentLinkPlugin;
 
 import jakarta.annotation.PostConstruct;
 
@@ -55,6 +57,8 @@ public class AnalyticsViewListener extends Listener<SpaceWebNotificationItem, Lo
   @ContainerTransactional
   public void onEvent(Event<SpaceWebNotificationItem, Long> event) {
     SpaceWebNotificationItem spaceWebNotificationItem = event.getSource();
-    activityViewProcessor.addActivityViewer(spaceWebNotificationItem.getApplicationItemId(), spaceWebNotificationItem.getUserId());
+    if (ActivityContentLinkPlugin.OBJECT_TYPE.equals(spaceWebNotificationItem.getApplicationName())) {
+      activityViewProcessor.addActivityViewer(spaceWebNotificationItem.getApplicationItemId(), spaceWebNotificationItem.getUserId());
+    }
   }
 }

--- a/analytics-services/src/main/java/io/meeds/analytics/plugin/ActivityViewProcessor.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/plugin/ActivityViewProcessor.java
@@ -138,6 +138,16 @@ public class ActivityViewProcessor extends BaseActivityProcessorPlugin {
   @SuppressWarnings("unchecked")
   public void addActivityViewer(String activityId, long userIdentityId) {
     ExoSocialActivity activity = activityManager.getActivity(activityId);
+    if (activity == null) {
+      LOG.warn("Can't add viewer user with IdentityId '{}' as viewer with the not found activity with id '{}'",
+               userIdentityId,
+               activityId);
+      return;
+    } else if (activity.isComment()
+               || StringUtils.isBlank(activity.getId())
+               || StringUtils.startsWith(activity.getId(), "comment")) {
+      return;
+    }
     String authorId = activity.getUserId();
     MetadataKey viewersMetadataKey = new MetadataKey(METADATA_TYPE.getName(), METADATA_NAME, Long.parseLong(authorId));
     List<MetadataItem> viewersMetadataItems = metadataService.getMetadataItemsByMetadataAndObject(viewersMetadataKey,


### PR DESCRIPTION
Prior to this change, the `ActivityProcessor` was triggered even when the Item Read event isn't about an activity. This lead to an `NPE` due to the missing Activity with the designated Id.