### PR TITLE
fix: prevent automatic alt mapping on typed field mismatch - EXO-87596

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/model/ProductOnlyStackTraceException.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/ProductOnlyStackTraceException.java
@@ -1,0 +1,100 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.analytics.model;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class ProductOnlyStackTraceException extends RuntimeException {
+
+  private static final String BASE_PACKAGE_COM_EXOPLATFORM = "com.exoplatform";
+
+  private static final String BASE_PACKAGE_ORG_EXOPLATFORM = "org.exoplatform";
+
+  private static final String BASE_PACKAGE_IO_MEEDS        = "io.meeds";
+
+  private static final long   serialVersionUID             = 2090796822546017069L;
+
+  private boolean             initialized;                                        // NOSONAR
+
+  @Override
+  public StackTraceElement[] getStackTrace() {
+    initStackTrace();
+    return super.getStackTrace();
+  }
+
+  @Override
+  public void printStackTrace(PrintStream s) {
+    initStackTrace();
+    super.printStackTrace(s);
+  }
+
+  @Override
+  public void printStackTrace(PrintWriter s) {
+    initStackTrace();
+    super.printStackTrace(s);
+  }
+
+  private void initStackTrace() {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+    StackTraceElement[] stackTrace = getStackTrace();
+    List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
+                                                      .filter(trace -> StringUtils.containsAny(trace.getClassName(),
+                                                                                               BASE_PACKAGE_IO_MEEDS,
+                                                                                               BASE_PACKAGE_ORG_EXOPLATFORM,
+                                                                                               BASE_PACKAGE_COM_EXOPLATFORM))
+                                                      .toList();
+    setStackTrace(productStackTrace.toArray(new StackTraceElement[productStackTrace.size()]));
+  }
+
+  @Override
+  public synchronized Throwable initCause(Throwable cause) {
+    StackTraceElement[] stackTrace = getStackTrace();
+    List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
+                                                      .filter(trace -> StringUtils.containsAny(trace.getClassName(),
+                                                                                               BASE_PACKAGE_IO_MEEDS,
+                                                                                               BASE_PACKAGE_ORG_EXOPLATFORM,
+                                                                                               BASE_PACKAGE_COM_EXOPLATFORM))
+                                                      .toList();
+    cause.setStackTrace(productStackTrace.toArray(new StackTraceElement[productStackTrace.size()]));
+    return super.initCause(cause);
+  }
+
+  @Override
+  public synchronized Throwable getCause() {
+    Throwable cause = super.getCause();
+    StackTraceElement[] stackTrace = getStackTrace();
+    List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
+                                                      .filter(trace -> StringUtils.containsAny(trace.getClassName(),
+                                                                                               BASE_PACKAGE_IO_MEEDS,
+                                                                                               BASE_PACKAGE_ORG_EXOPLATFORM,
+                                                                                               BASE_PACKAGE_COM_EXOPLATFORM))
+                                                      .toList();
+    cause.setStackTrace(productStackTrace.toArray(new StackTraceElement[productStackTrace.size()]));
+    return cause;
+  }
+}

--- a/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
@@ -20,25 +20,46 @@
 package io.meeds.analytics.model;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.utils.PropertyManager;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Slf4j
 public class StatisticData implements Serializable {
+
+  private static final ZoneId             DEFAULT_ZONE_ID  = ZoneId.systemDefault();
+
+  private static final boolean            DEVELOPPING      = PropertyManager.isDevelopping();
 
   private static final List<Class<?>>     PRIMITIVE_TYPES  = List.of(Boolean.class,
                                                                      Byte.class,
@@ -48,11 +69,22 @@ public class StatisticData implements Serializable {
                                                                      Float.class,
                                                                      Double.class);
 
+  private static final List<Class<?>>     DATE_TYPES       = List.of(Date.class,
+                                                                     Calendar.class,
+                                                                     Instant.class,
+                                                                     ZonedDateTime.class,
+                                                                     OffsetDateTime.class,
+                                                                     LocalDateTime.class,
+                                                                     LocalDate.class);
+
   private static final long               serialVersionUID = -2660993500359866340L;
 
-  private static final int                PRIME            = 59;
+  private static final String             HASH_ALGORITHM   = "SHA-256";
 
   private final String                    uuid             = UUID.randomUUID().toString();
+
+  @ToString.Exclude
+  private transient volatile Long         computedId;
 
   @ToString.Exclude
   private DateFormat                      dateFormat;
@@ -77,16 +109,198 @@ public class StatisticData implements Serializable {
 
   private long                            errorCode;
 
-  private Map<String, Object>             parameters;                                     // NOSONAR
+  private Map<String, Object>             parameters;                                        // NOSONAR
 
-  private Map<String, Collection<Object>> listParameters;                                 // NOSONAR
+  private Map<String, Collection<Object>> listParameters;                                    // NOSONAR
 
-  public void addParameter(String key, Object value) {
+  public enum StatisticStatus {
+    OK, KO;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    return this == o || o instanceof StatisticData other && computeId() == other.computeId();
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(computeId());
+  }
+
+  /**
+   * Add a textual statistic data parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addKeyword(String key, Object value) {
+    if (value != null) {
+      if (value instanceof Collection c) { // NOSONAR
+        addKeywords(key, c);
+      } else {
+        addParameterValue(key, String.valueOf(value));
+      }
+    }
+  }
+
+  /**
+   * Add a textual statistic data list parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addKeywords(String key, Collection<?> value) {
+    if (value == null) {
+      return;
+    }
+    addListParameterValues(key,
+                           value.stream()
+                                .filter(Objects::nonNull)
+                                .map(String::valueOf)
+                                .toList());
+  }
+
+  /**
+   * Add a long statistic data parameter. Used for fields used to aggregate
+   * count, mean, min, max or for timestamp only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addLong(String key, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection c) { // NOSONAR
+      addLongs(key, c);
+      return;
+    }
+    Long longValue = parseLongValue(key, value);
+    if (longValue != null) {
+      addParameterValue(key, longValue);
+    }
+  }
+
+  /**
+   * Add a long statistic data list parameter. Used for fields used to aggregate
+   * count, mean, min, max or for timestamp only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addLongs(String key, Collection<?> value) {
+    if (value != null) {
+      addListParameterValues(key,
+                             value.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(v -> parseLongValue(key, v))
+                                  .filter(Objects::nonNull)
+                                  .toList());
+    }
+  }
+
+  /**
+   * Add a double statistic data parameter. Used for fields used to aggregate
+   * count, mean, min or max only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addDouble(String key, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection c) { // NOSONAR
+      addDoubles(key, c);
+      return;
+    }
+    Double doubleValue = parseDoubleValue(key, value);
+    if (doubleValue != null) {
+      addParameterValue(key, doubleValue);
+    }
+  }
+
+  /**
+   * Add a double statistic data list parameter. Used for fields used to
+   * aggregate count, mean, min or max only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addDoubles(String key, Collection<?> value) {
+    if (value != null) {
+      addListParameterValues(key,
+                             value.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(v -> parseDoubleValue(key, v))
+                                  .filter(Objects::nonNull)
+                                  .toList());
+    }
+  }
+
+  /**
+   * Add a boolean statistic data parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addBoolean(String key, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection c) { // NOSONAR
+      addBooleans(key, c);
+      return;
+    }
+    Boolean booleanValue = parseBooleanValue(key, value);
+    if (booleanValue != null) {
+      addParameterValue(key, booleanValue);
+    }
+  }
+
+  /**
+   * Add a boolean statistic data list parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addBooleans(String key, Collection<?> value) {
+    if (value != null) {
+      addListParameterValues(key,
+                             value.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(v -> parseBooleanValue(key, v))
+                                  .filter(Objects::nonNull)
+                                  .toList());
+    }
+  }
+
+  public void addDate(String key, Object value) {
+    addLong(key, value);
+  }
+
+  public void addDates(String key, Collection<?> value) {
+    addLongs(key, value);
+  }
+
+  /**
+   * Add a statistic data parameter
+   * 
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   * @deprecated Use addKeyword, addLong, addDouble, addBoolean, or their
+   *             collection variants to avoid ambiguous ES mappings.
+   */
+  @Deprecated(since = "7.2.0")
+  public void addParameter(String key, Object value) { // NOSONAR
     if (parameters == null) {
       parameters = new HashMap<>();
     }
     if (value == null) {
       return;
+    }
+    if (DEVELOPPING || log.isDebugEnabled()) {
+      log.warn("A statistic data field is collected using a deprecated API", new ProductOnlyStackTraceException());
     }
     if (value instanceof Collection) {
       Collection<?> collection = (Collection<?>) value;
@@ -101,6 +315,133 @@ public class StatisticData implements Serializable {
     } else {
       parameters.put(key, getFieldValue(value));
     }
+    resetComputedId();
+  }
+
+  public long computeId() {
+    Long localComputedId = computedId;
+    if (localComputedId == null) {
+      localComputedId = doComputeId();
+      computedId = localComputedId;
+    }
+    return localComputedId;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+    resetComputedId();
+  }
+
+  public void setUserId(long userId) {
+    this.userId = userId;
+    resetComputedId();
+  }
+
+  public void setSpaceId(long spaceId) {
+    this.spaceId = spaceId;
+    resetComputedId();
+  }
+
+  public void setModule(String module) {
+    this.module = module;
+    resetComputedId();
+  }
+
+  public void setSubModule(String subModule) {
+    this.subModule = subModule;
+    resetComputedId();
+  }
+
+  public void setOperation(String operation) {
+    this.operation = operation;
+    resetComputedId();
+  }
+
+  public void setParameters(Map<String, Object> parameters) {
+    this.parameters = parameters;
+    resetComputedId();
+  }
+
+  public void setListParameters(Map<String, Collection<Object>> listParameters) {
+    this.listParameters = listParameters;
+    resetComputedId();
+  }
+
+  private long doComputeId() {
+    byte[] digest = computeDigest(buildIdSource());
+    return ((long) (digest[0] & 0xff) << 56)
+        | ((long) (digest[1] & 0xff) << 48)
+        | ((long) (digest[2] & 0xff) << 40)
+        | ((long) (digest[3] & 0xff) << 32)
+        | ((long) (digest[4] & 0xff) << 24)
+        | ((long) (digest[5] & 0xff) << 16)
+        | ((long) (digest[6] & 0xff) << 8)
+        | ((long) (digest[7] & 0xff)); // NOSONAR
+  }
+
+  private String buildIdSource() {
+    StringBuilder builder = new StringBuilder();
+    appendIdPart(builder, timestamp);
+    appendIdPart(builder, userId);
+    appendIdPart(builder, spaceId);
+    appendIdPart(builder, module);
+    appendIdPart(builder, subModule);
+    appendIdPart(builder, operation);
+    appendMap(builder, parameters);
+    appendMap(builder, listParameters);
+    appendIdPart(builder, uuid);
+    return builder.toString();
+  }
+
+  private void appendMap(StringBuilder builder, Map<String, ?> map) {
+    if (map == null || map.isEmpty()) {
+      appendIdPart(builder, null);
+      return;
+    }
+    builder.append("map{");
+    map.entrySet()
+       .stream()
+       .sorted(Entry.comparingByKey())
+       .forEach(entry -> {
+         appendIdPart(builder, entry.getKey());
+         appendValue(builder, entry.getValue());
+       });
+    builder.append('}');
+  }
+
+  private void appendValue(StringBuilder builder, Object value) {
+    if (value instanceof Collection<?> collection) {
+      builder.append("collection[");
+      collection.stream()
+                .filter(Objects::nonNull)
+                .map(String::valueOf)
+                .sorted()
+                .forEach(item -> appendIdPart(builder, item));
+      builder.append(']');
+    } else {
+      appendIdPart(builder, value);
+    }
+  }
+
+  private void appendIdPart(StringBuilder builder, Object value) {
+    String stringValue = String.valueOf(value);
+    builder.append(stringValue.length())
+           .append(':')
+           .append(stringValue)
+           .append('|');
+  }
+
+  private byte[] computeDigest(String value) {
+    try {
+      return MessageDigest.getInstance(HASH_ALGORITHM)
+                          .digest(value.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Unable to compute statistic data identifier", e);
+    }
+  }
+
+  private void resetComputedId() {
+    computedId = null;
   }
 
   private Object getFieldValue(Object value) {
@@ -117,6 +458,10 @@ public class StatisticData implements Serializable {
     return PRIMITIVE_TYPES.stream().anyMatch(c -> c.isAssignableFrom(value.getClass()));
   }
 
+  private static boolean isDate(Object value) {
+    return DATE_TYPES.stream().anyMatch(c -> c.isAssignableFrom(value.getClass()));
+  }
+
   private DateFormat buildDateFormat() {
     if (dateFormat == null) {
       dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss Z");
@@ -124,33 +469,88 @@ public class StatisticData implements Serializable {
     return dateFormat;
   }
 
-  public enum StatisticStatus {
-    OK, KO;
+  private long toEpochMillis(Object value) {
+    return switch (value) {
+    case Date date -> date.getTime();
+    case Calendar calendar -> calendar.getTimeInMillis();
+    case Instant instant -> instant.toEpochMilli();
+    case ZonedDateTime zonedDateTime -> zonedDateTime.toInstant().toEpochMilli();
+    case OffsetDateTime offsetDateTime -> offsetDateTime.toInstant().toEpochMilli();
+    case LocalDateTime localDateTime -> localDateTime.atZone(DEFAULT_ZONE_ID).toInstant().toEpochMilli();
+    case LocalDate localDate -> localDate.atStartOfDay(DEFAULT_ZONE_ID).toInstant().toEpochMilli();
+    default -> Long.parseLong(String.valueOf(value));
+    };
   }
 
-  public long computeId() {
-    long result = timestamp;
-    result = result * PRIME + (int) (userId >>> 32 ^ userId);
-    result = result * PRIME + (int) (spaceId >>> 32 ^ spaceId);
-    result = result * PRIME + (module == null ? 43 : module.hashCode());
-    result = result * PRIME + (subModule == null ? 43 : subModule.hashCode());
-    result = result * PRIME + (operation == null ? 43 : operation.hashCode());
-    result = result * PRIME + (parameters == null ? 43 : parameters.hashCode());
-    result = result * PRIME + uuid.hashCode();
-    return result;
+  private void addParameterValue(String key, Object value) {
+    if (StringUtils.isBlank(key) || value == null) {
+      return;
+    }
+    if (parameters == null) {
+      parameters = new HashMap<>();
+    }
+    parameters.put(key, value);
+    resetComputedId();
   }
 
-  public boolean equals(final java.lang.Object o) {
-    if (o == this)
-      return true;
-    if (!(o instanceof StatisticData))
-      return false;
-    final StatisticData other = (StatisticData) o;
-    return hashCode() == other.hashCode();
+  private void addListParameterValues(String key, Collection<?> value) {
+    if (StringUtils.isBlank(key) || value == null) {
+      return;
+    }
+    Collection<Object> values = value.stream()
+                                     .filter(Objects::nonNull)
+                                     .map(Object.class::cast)
+                                     .toList();
+    if (values.isEmpty()) {
+      return;
+    }
+    if (listParameters == null) {
+      listParameters = new HashMap<>();
+    }
+    listParameters.put(key, values);
+    resetComputedId();
   }
 
-  public int hashCode() {
-    return (int) computeId();
+  private Long parseLongValue(String key, Object value) {
+    try {
+      return isDate(value) ? toEpochMillis(value) : Long.parseLong(String.valueOf(value));
+    } catch (RuntimeException e) {
+      logInvalidTypedValue(key, value, "long");
+      return null;
+    }
+  }
+
+  private Double parseDoubleValue(String key, Object value) {
+    try {
+      return Double.parseDouble(String.valueOf(value));
+    } catch (RuntimeException e) {
+      logInvalidTypedValue(key, value, "double");
+      return null;
+    }
+  }
+
+  private Boolean parseBooleanValue(String key, Object value) {
+    String stringValue = String.valueOf(value);
+    if (StringUtils.equalsAnyIgnoreCase(stringValue, "true", "false")) {
+      return Boolean.parseBoolean(stringValue);
+    }
+    logInvalidTypedValue(key, value, "boolean");
+    return null; // NOSONAR
+  }
+
+  private void logInvalidTypedValue(String key, Object value, String type) {
+    if (DEVELOPPING || log.isDebugEnabled()) {
+      log.warn("Invalid {} statistic value for field '{}' and value {}. Field will be ignored",
+               type,
+               key,
+               value,
+               new ProductOnlyStackTraceException());
+    } else {
+      log.warn("Invalid {} statistic value for field '{}' and value {}. Field will be ignored",
+               type,
+               key,
+               value);
+    }
   }
 
 }

--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -442,18 +442,18 @@ public class AnalyticsUtils {
       return;
     }
     statisticData.setSpaceId(Long.parseLong(space.getId()));
-    statisticData.addParameter("parentSpaceId", space.getParentSpaceId());
-    statisticData.addParameter("spaceTemplateId", space.getTemplateId());
-    statisticData.addParameter("spaceCategoryIds", space.getCategoryIds());
-    statisticData.addParameter("spaceVisibility", space.getVisibility());
-    statisticData.addParameter("spaceRegistration", space.getRegistration());
-    statisticData.addParameter("spaceCreatedTime", space.getCreatedTime());
-    statisticData.addParameter("spaceMembersCount", getSize(space.getMembers()));
-    statisticData.addParameter("spaceManagersCount", getSize(space.getManagers()));
-    statisticData.addParameter("spaceRedactorsCount", getSize(space.getRedactors()));
-    statisticData.addParameter("spaceInviteesCount", getSize(space.getInvitedUsers()));
-    statisticData.addParameter("spacePendingCount", getSize(space.getPendingUsers()));
-    statisticData.addParameter("spaceSovereign", space.isSovereign());
+    statisticData.addKeyword("parentSpaceId", space.getParentSpaceId());
+    statisticData.addKeyword("spaceTemplateId", space.getTemplateId());
+    statisticData.addKeyword("spaceCategoryIds", space.getCategoryIds());
+    statisticData.addKeyword("spaceVisibility", space.getVisibility());
+    statisticData.addKeyword("spaceRegistration", space.getRegistration());
+    statisticData.addLong("spaceCreatedTime", space.getCreatedTime());
+    statisticData.addLong("spaceMembersCount", getSize(space.getMembers()));
+    statisticData.addLong("spaceManagersCount", getSize(space.getManagers()));
+    statisticData.addLong("spaceRedactorsCount", getSize(space.getRedactors()));
+    statisticData.addLong("spaceInviteesCount", getSize(space.getInvitedUsers()));
+    statisticData.addLong("spacePendingCount", getSize(space.getPendingUsers()));
+    statisticData.addBoolean("spaceSovereign", space.isSovereign());
   }
 
   public static void addActivityStatisticsData(StatisticData statisticData, ExoSocialActivity activity) {
@@ -463,17 +463,17 @@ public class AnalyticsUtils {
     String activityId = activity.getParentId() == null ? activity.getId() : activity.getParentId();
     String commentId = activity.getParentCommentId() == null ? activity.getId() : activity.getParentCommentId();
     String subCommentId = activity.getParentCommentId() == null ? null : activity.getId();
-    statisticData.addParameter("activityType", getActivityType(activity));
+    statisticData.addKeyword("activityType", getActivityType(activity));
     if (StringUtils.isNotBlank(activityId)) {
-      statisticData.addParameter("activityId", activityId);
+      statisticData.addKeyword("activityId", activityId);
     }
     if (StringUtils.isNotBlank(commentId)) {
       commentId = commentId.replace(ACTIVITY_COMMENT, "");
-      statisticData.addParameter(ACTIVITY_COMMENT, commentId);
+      statisticData.addKeyword(ACTIVITY_COMMENT, commentId);
     }
     if (StringUtils.isNotBlank(subCommentId)) {
       subCommentId = subCommentId.replace(ACTIVITY_COMMENT, "");
-      statisticData.addParameter("subCommentId", subCommentId);
+      statisticData.addKeyword("subCommentId", subCommentId);
     }
   }
 
@@ -486,18 +486,18 @@ public class AnalyticsUtils {
     if (category == null) {
       return;
     }
-    statisticData.addParameter("categoryId", category.getId());
-    statisticData.addParameter("categoryIcon", category.getIcon());
-    statisticData.addParameter("categoryLinkPermissions", category.getLinkPermissions());
-    statisticData.addParameter("categoryCreatorId", category.getCreatorId());
-    statisticData.addParameter("categoryOwnerId", category.getOwnerId());
-    statisticData.addParameter("categoryParentId", category.getParentId());
+    statisticData.addKeyword("categoryId", category.getId());
+    statisticData.addKeyword("categoryIcon", category.getIcon());
+    statisticData.addKeyword("categoryLinkPermissions", category.getLinkPermissions());
+    statisticData.addKeyword("categoryCreatorId", category.getCreatorId());
+    statisticData.addKeyword("categoryOwnerId", category.getOwnerId());
+    statisticData.addKeyword("categoryParentId", category.getParentId());
   }
 
   public static void addCategoryLinkStatistics(StatisticData statisticData, CategoryObject categoryObject) {
-    statisticData.addParameter("categoryObjectType", categoryObject.getType());
-    statisticData.addParameter("categoryObjectId", categoryObject.getId());
-    statisticData.addParameter("categoryObjectParentId", categoryObject.getParentId());
+    statisticData.addKeyword("categoryObjectType", categoryObject.getType());
+    statisticData.addKeyword("categoryObjectId", categoryObject.getId());
+    statisticData.addKeyword("categoryObjectParentId", categoryObject.getParentId());
     if (categoryObject.getSpaceId() > 0) {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
       Space space = spaceService.getSpaceById(categoryObject.getSpaceId());
@@ -557,7 +557,7 @@ public class AnalyticsUtils {
                         Object propertyValue = properties.get(propertyName);
                         if (properties.containsKey(propertyName)) {
                           if (propertyValue instanceof String value) {
-                            statisticData.addParameter(String.join(".", PROFILE_PROPERTIES, propertyName), value);
+                            statisticData.addKeyword(String.join(".", PROFILE_PROPERTIES, propertyName), value);
                           } else if (!property.isHasChildProperties()
                               && propertyValue instanceof List<?> values) {
                             @SuppressWarnings("unchecked")
@@ -566,7 +566,7 @@ public class AnalyticsUtils {
                                                                  .map(prop -> prop.get("value"))
                                                                  .filter(Objects::nonNull)
                                                                  .toList();
-                            statisticData.addParameter(String.join(".", PROFILE_PROPERTIES, propertyName), valuesList);
+                            statisticData.addKeyword(String.join(".", PROFILE_PROPERTIES, propertyName), valuesList);
                           }
                         }
                       });

--- a/analytics-listeners/src/main/java/io/meeds/analytics/job/SpacesStatisticsCountJob.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/job/SpacesStatisticsCountJob.java
@@ -55,8 +55,8 @@ public class SpacesStatisticsCountJob {
     statisticData.setSubModule("space");
     statisticData.setOperation("spacesCount");
     statisticData.setDuration(System.currentTimeMillis() - startTime);
-    statisticData.addParameter("countType", "allSpaces");
-    statisticData.addParameter("count", allSpacesCount);
+    statisticData.addKeyword("countType", "allSpaces");
+    statisticData.addLong("count", allSpacesCount);
     AnalyticsUtils.addStatisticData(statisticData);
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/job/UsersStatisticsCountJob.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/job/UsersStatisticsCountJob.java
@@ -92,8 +92,8 @@ public class UsersStatisticsCountJob {
     statisticData.setSubModule("account");
     statisticData.setOperation("usersCount");
     statisticData.setDuration(System.currentTimeMillis() - startTime);
-    statisticData.addParameter("countType", countType);
-    statisticData.addParameter("count", count);
+    statisticData.addKeyword("countType", countType);
+    statisticData.addLong("count", count);
     AnalyticsUtils.addStatisticData(statisticData);
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientRegisterErrorListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientRegisterErrorListener.java
@@ -83,22 +83,22 @@ public class OAuthClientRegisterErrorListener implements ListenerBase<Object, Ru
   }
 
   private void addOAuthClientFields(StatisticData statisticData, OAuthCimdClientMetadata client) {
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, client.clientId());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_NAME, client.clientName());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.redirectUris());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.tokenEndpointAuthMethod());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.grantTypes());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.responseTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, client.clientId());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_NAME, client.clientName());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.redirectUris());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.tokenEndpointAuthMethod());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.grantTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.responseTypes());
   }
 
   private void addOAuthClientFields(StatisticData statisticData, OidcClientRegistration client) {
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, client.getClientId());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_SCOPES, client.getScopes());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.getTokenEndpointAuthenticationMethod());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.getGrantTypes());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.getResponseTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, client.getClientId());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_SCOPES, client.getScopes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.getTokenEndpointAuthenticationMethod());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.getGrantTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.getResponseTypes());
   }
 
 }

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentConsumerListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentConsumerListener.java
@@ -81,7 +81,7 @@ public class OAuthConsentConsumerListener implements ListenerBase<OAuth2Authoriz
       if (client != null) {
         addOAuthClientFields(statisticData, client);
       } else {
-        statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
+        statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
       }
       addOAuthConsentFields(statisticData, consent);
       addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentListener.java
@@ -100,7 +100,7 @@ public class OAuthConsentListener implements ListenerBase<OAuth2AuthorizationCon
         if (client != null) {
           addOAuthClientFields(statisticData, client);
         } else {
-          statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
+          statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
         }
         addOAuthConsentFields(statisticData, consent);
         addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenConsumerListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenConsumerListener.java
@@ -88,11 +88,11 @@ public class OAuthTokenConsumerListener implements ListenerBase<OAuth2Authorizat
       if (client != null) {
         addOAuthClientFields(statisticData, client);
       } else {
-        statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, clientId);
+        statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, clientId);
       }
       addOAuthTokenFields(statisticData, token);
       if (tokenType != null) {
-        statisticData.addParameter(PARAM_OAUTH_TOKEN_TYPE, tokenType);
+        statisticData.addKeyword(PARAM_OAUTH_TOKEN_TYPE, tokenType);
       }
       addStatisticData(statisticData);
     }

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenListener.java
@@ -100,7 +100,7 @@ public class OAuthTokenListener implements ListenerBase<OAuth2Authorization, OAu
         if (client != null) {
           addOAuthClientFields(statisticData, client);
         } else {
-          statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, token.getRegisteredClientId());
+          statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, token.getRegisteredClientId());
         }
         addOAuthTokenFields(statisticData, token);
         addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/LoginFailedAnalyticsListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/LoginFailedAnalyticsListener.java
@@ -65,7 +65,7 @@ public class LoginFailedAnalyticsListener extends Listener<String, Map<String, S
     statisticData.setUserId(AnalyticsUtils.getUserIdentityId(data.get("user_id")));
     statisticData.setStatus(data.get("status").equals("ko") ? StatisticData.StatisticStatus.KO :
                                                             StatisticData.StatisticStatus.OK);
-    statisticData.addParameter("reason", data.get("reason"));
+    statisticData.addKeyword("reason", data.get("reason"));
     addStatisticData(statisticData);
   }
 }

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/PageAccessListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/PageAccessListener.java
@@ -115,31 +115,31 @@ public class PageAccessListener extends BaseComponentPlugin implements Applicati
       Space space = SpaceUtils.getSpaceByContext();
       addSpaceStatistics(statisticData, space);
 
-      statisticData.addParameter("httpRequestMethod", httpRequest.getMethod());
-      statisticData.addParameter("httpRequestUri", httpRequest.getRequestURI());
-      statisticData.addParameter("httpRequestProtocol", httpRequest.getProtocol());
-      statisticData.addParameter("httpRequestContentType", httpRequest.getContentType());
-      statisticData.addParameter("httpRequestContentLength", httpRequest.getContentLength());
+      statisticData.addKeyword("httpRequestMethod", httpRequest.getMethod());
+      statisticData.addKeyword("httpRequestUri", httpRequest.getRequestURI());
+      statisticData.addKeyword("httpRequestProtocol", httpRequest.getProtocol());
+      statisticData.addKeyword("httpRequestContentType", httpRequest.getContentType());
+      statisticData.addLong("httpRequestContentLength", httpRequest.getContentLength());
 
-      statisticData.addParameter("userLocale", portalRequestContext.getLocale());
-      statisticData.addParameter("portalOwner", portalRequestContext.getPortalOwner());
-      statisticData.addParameter("portalUri", portalRequestContext.getPortalURI());
-      statisticData.addParameter("pageTitle", portalRequestContext.getTitle());
+      statisticData.addKeyword("userLocale", portalRequestContext.getLocale());
+      statisticData.addKeyword("portalOwner", portalRequestContext.getPortalOwner());
+      statisticData.addKeyword("portalUri", portalRequestContext.getPortalURI());
+      statisticData.addKeyword("pageTitle", portalRequestContext.getTitle());
 
       UIPortal uiportal = Util.getUIPortal();
       if (uiportal != null) {
         UserNode node = uiportal.getSelectedUserNode();
         if (node != null) {
-          statisticData.addParameter("pageUri", node.getURI());
-          statisticData.addParameter("pageName", node.getName());
+          statisticData.addKeyword("pageUri", node.getURI());
+          statisticData.addKeyword("pageName", node.getName());
         }
       }
 
       HttpServletResponse httpResponse = portalRequestContext.getResponse();
       if (httpResponse != null) {
-        statisticData.addParameter("httpResponseContentType", httpResponse.getContentType());
-        statisticData.addParameter("httpResponseContentLength", httpResponse.getBufferSize());
-        statisticData.addParameter("httpResponseStatus", httpResponse.getStatus());
+        statisticData.addKeyword("httpResponseContentType", httpResponse.getContentType());
+        statisticData.addLong("httpResponseContentLength", httpResponse.getBufferSize());
+        statisticData.addKeyword("httpResponseStatus", httpResponse.getStatus());
 
         if (httpResponse.getStatus() >= 400) {
           statisticData.setErrorCode(httpResponse.getStatus());

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/UserAnalyticsEventListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/UserAnalyticsEventListener.java
@@ -100,14 +100,14 @@ public class UserAnalyticsEventListener extends UserEventListener {
       statisticData.setOperation(operation);
       statisticData.setDuration(getDuration());
       statisticData.setUserId(getCurrentUserIdentityId());
-      statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(user.getUserName()));
-      statisticData.addParameter("isEnabled", user.isEnabled());
+      statisticData.addKeyword(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(user.getUserName()));
+      statisticData.addBoolean("isEnabled", user.isEnabled());
       if (OrganizationService.EXTERNAL_STORE.equals(user.getOriginatingStore())) {
-        statisticData.addParameter("userSource", EXTERNAL_USER_SOURCE);
+        statisticData.addKeyword("userSource", EXTERNAL_USER_SOURCE);
       } else {
-        statisticData.addParameter("userSource", user.getCreationSource());
+        statisticData.addKeyword("userSource", user.getCreationSource());
       }
-      statisticData.addParameter("modificationSource", UserModificationSource.getSourceOrDefault("ui"));
+      statisticData.addKeyword("modificationSource", UserModificationSource.getSourceOrDefault("ui"));
       return statisticData;
     } catch (Exception e) {
       LOG.warn("Error building analytics Queue entry for operation {}", operation, e);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityListener.java
@@ -175,7 +175,7 @@ public class AnalyticsActivityListener extends ActivityListenerPlugin {
     String[] likeIdentityIds = event.getActivity().getLikeIdentityIds();
     if (likeIdentityIds != null && likeIdentityIds.length > 0) {
       String likerId = likeIdentityIds[likeIdentityIds.length - 1];
-      statisticData.addParameter("likeIdentityId", likerId);
+      statisticData.addKeyword("likeIdentityId", likerId);
     }
   }
 
@@ -229,7 +229,7 @@ public class AnalyticsActivityListener extends ActivityListenerPlugin {
         Space space = spaceService.getSpaceByPrettyName(streamIdentity.getRemoteId());
         addSpaceStatistics(statisticData, space);
       }
-      statisticData.addParameter("streamIdentityId", streamIdentity.getIdentityId());
+      statisticData.addKeyword("streamIdentityId", streamIdentity.getIdentityId());
     }
 
     statisticData.setModule("social");

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityTagsListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityTagsListener.java
@@ -87,10 +87,10 @@ public class AnalyticsActivityTagsListener extends Listener<TagObject, Set<TagNa
     statisticData.setOperation("Add tag");
     statisticData.setTimestamp(new Date().getTime());
     statisticData.setUserId(Long.parseLong(activity.getUserId()));
-    statisticData.addParameter("username", username);
-    statisticData.addParameter("type", objectType);
-    statisticData.addParameter("dataType", StringUtils.lowerCase(objectType));
-    statisticData.addParameter("spaceIdentityId", audienceIdentity.getIdentityId());
+    statisticData.addKeyword("username", username);
+    statisticData.addKeyword("type", objectType);
+    statisticData.addKeyword("dataType", StringUtils.lowerCase(objectType));
+    statisticData.addKeyword("spaceIdentityId", audienceIdentity.getIdentityId());
 
     for (int i = 0; i < numberOfTags; i++) {
       AnalyticsUtils.addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsProfileListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsProfileListener.java
@@ -65,8 +65,8 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
       if (avatarAttachment != null) {
         StatisticData statisticData = buildStatisticData(AVATAR, event.getSource());
         if (statisticData != null) {
-          statisticData.addParameter(IMAGE_SIZE, avatarAttachment.getSize());
-          statisticData.addParameter(IMAGE_TYPE, avatarAttachment.getMimeType());
+          statisticData.addLong(IMAGE_SIZE, avatarAttachment.getSize());
+          statisticData.addKeyword(IMAGE_TYPE, avatarAttachment.getMimeType());
           addStatisticData(statisticData);
         }
       }
@@ -132,8 +132,8 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
     statisticData.setSubModule("profile");
     statisticData.setOperation(operation);
     statisticData.setUserId(Long.parseLong(identity.getId()));
-    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, identity.getIdentityId());
-    statisticData.addParameter("userCreatedDate", identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
+    statisticData.addKeyword(FIELD_SOCIAL_IDENTITY_ID, identity.getIdentityId());
+    statisticData.addLong("userCreatedDate", identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsRelationshipListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsRelationshipListener.java
@@ -121,8 +121,8 @@ public class AnalyticsRelationshipListener extends RelationshipListenerPlugin {
     statisticData.setSubModule("relationship");
     statisticData.setOperation(operation);
     statisticData.setUserId(getCurrentUserIdentityId());
-    statisticData.addParameter("from", from);
-    statisticData.addParameter("to", to);
+    statisticData.addKeyword("from", from);
+    statisticData.addKeyword("to", to);
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceListener.java
@@ -225,7 +225,7 @@ public class AnalyticsSpaceListener extends SpaceListenerPlugin {
     statisticData.setOperation("joinedByInvitationLink");
     statisticData.setSpaceId(space.getSpaceId());
     statisticData.setUserId(getUserIdentityId(event.getSource()));
-    statisticData.addParameter("inviterId", getUserIdentityId(event.getInviterId()));
+    statisticData.addKeyword("inviterId", getUserIdentityId(event.getInviterId()));
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
@@ -89,15 +89,15 @@ public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNoti
       return;
     }
     if (StringUtils.isNotBlank(spaceWebNotificationItem.getApplicationName())) {
-      statisticData.addParameter("entityType", spaceWebNotificationItem.getApplicationName());
+      statisticData.addKeyword("entityType", spaceWebNotificationItem.getApplicationName());
     }
     if (StringUtils.isNotBlank(spaceWebNotificationItem.getApplicationItemId())) {
-      statisticData.addParameter("entityId", spaceWebNotificationItem.getApplicationItemId());
+      statisticData.addKeyword("entityId", spaceWebNotificationItem.getApplicationItemId());
     }
     if (spaceWebNotificationItem instanceof SpaceWebNotificationItemUpdate spaceWebNotificationItemUpdate) {
       String userEvent = spaceWebNotificationItemUpdate.getUserEvent();
       if (StringUtils.isNotBlank(userEvent)) {
-        statisticData.addParameter("event-type", userEvent);
+        statisticData.addKeyword("event-type", userEvent);
       }
     }
     addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/websocket/WebSocketUIStatisticListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/websocket/WebSocketUIStatisticListener.java
@@ -130,9 +130,9 @@ public class WebSocketUIStatisticListener extends Listener<AnalyticsWebSocketSer
       String dataParameterValue = dataParameter.getValue();
       if (StringUtils.contains(dataParameterValue, ",")) {
         List<String> dataParameterValues = Arrays.asList(StringUtils.split(dataParameterValue, ","));
-        statisticData.addParameter(dataParameterName, dataParameterValues);
+        statisticData.addKeywords(dataParameterName, dataParameterValues);
       } else {
-        statisticData.addParameter(dataParameterName, dataParameterValue);
+        statisticData.addKeyword(dataParameterName, dataParameterValue);
       }
     }
     addStatisticData(statisticData);

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
@@ -38,9 +38,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +46,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -111,7 +110,9 @@ public class ElasticsearchAnalyticsStorage {
   public static final DateTimeFormatter DAY_DATE_FORMATTER   = DateTimeFormatter.ofPattern(DAY_DATE_FORMAT)
                                                                                 .withResolverStyle(ResolverStyle.LENIENT);
 
-  private List<String>                  ignoredFieldNames    = Collections.synchronizedList(new ArrayList<>());
+  private Set<String>                   ignoredFieldNames    = ConcurrentHashMap.newKeySet();
+
+  private Map<String, String>           mappedFieldNames     = new ConcurrentHashMap<>();
 
   @Autowired
   private ListenerService               listenerService;
@@ -364,7 +365,7 @@ public class ElasticsearchAnalyticsStorage {
       data.getParameters()
           .keySet()
           .stream()
-          .filter(p -> !mappedFields.containsKey(p))
+          .filter(p -> getFieldMapping(mappedFields, p) == null)
           .forEach(f -> createFieldMapping(f, data.getParameters().get(f)));
       Map<String, String> parameters = data.getParameters()
                                            .entrySet()
@@ -373,30 +374,35 @@ public class ElasticsearchAnalyticsStorage {
                                            .map(e -> {
                                              String name = e.getKey();
                                              Object value = e.getValue();
-                                             StatisticFieldMapping mapping = mappedFields.get(name);
+                                             if (value == null) {
+                                               return null;
+                                             }
+                                             StatisticFieldMapping mapping = getFieldMapping(mappedFields, name);
                                              String altFieldName = "%s_alt".formatted(name);
-                                             if (mappedFields.containsKey(altFieldName)) {
-                                               return Pair.of(altFieldName, value);
+                                             StatisticFieldMapping altMapping = getFieldMapping(mappedFields, altFieldName);
+                                             if (altMapping != null) {
+                                               if (checkFieldMapping(value, altMapping)) {
+                                                 return normalizeFieldValueForMapping(Pair.of(altFieldName, value), altMapping);
+                                               }
+                                               if (ignoredFieldNames.add(altFieldName)) {
+                                                 LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES alternative type '{}'. Ignore adding it in indexed document {}",
+                                                          name,
+                                                          getFieldMappingType(value),
+                                                          altMapping.getType(),
+                                                          data.getParameters());
+                                               }
+                                               return null;
                                              } else if (checkFieldMapping(value, mapping)) {
-                                               return e;
-                                             } else if (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
-                                                        || mapping.getType().equals(TEXT_MAPPING_TYPE)) {
-                                               String altFieldType = createFieldMapping(altFieldName, value);
-                                               LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}'",
-                                                        name,
-                                                        altFieldName,
-                                                        mapping.getType(),
-                                                        altFieldType);
-                                               return Pair.of(altFieldName, value);
+                                               return normalizeFieldValueForMapping(e, mapping);
                                              } else {
                                                // Start:: Log the same field
                                                // only once
-                                               if (!ignoredFieldNames.contains(name)) {
-                                                 ignoredFieldNames.add(name);
-                                                 LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
+                                               if (ignoredFieldNames.add(name)) {
+                                                 LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document {}",
                                                           name,
                                                           getFieldMappingType(value),
-                                                          mapping.getType());
+                                                          mapping.getType(),
+                                                          data.getParameters());
                                                }
                                                // End:: Log the same field only
                                                // once
@@ -416,7 +422,7 @@ public class ElasticsearchAnalyticsStorage {
       data.getListParameters()
           .keySet()
           .stream()
-          .filter(p -> !mappedFields.containsKey(p))
+          .filter(p -> getFieldMapping(mappedFields, p) == null)
           .filter(p -> CollectionUtils.isNotEmpty(data.getListParameters().get(p)))
           .forEach(p -> createFieldMapping(p, data.getListParameters().get(p)));
       Map<String, Collection<String>> parameters = data.getListParameters()
@@ -426,27 +432,30 @@ public class ElasticsearchAnalyticsStorage {
                                                        .map(e -> {
                                                          Collection<Object> value = e.getValue();
                                                          String name = e.getKey();
-                                                         StatisticFieldMapping mapping = mappedFields.get(name);
+                                                         StatisticFieldMapping mapping = getFieldMapping(mappedFields, name);
                                                          String altFieldName = "%s_alt".formatted(name);
-                                                         if (mappedFields.containsKey(altFieldName)) {
-                                                           return Pair.of(altFieldName, value);
+                                                         StatisticFieldMapping altMapping = getFieldMapping(mappedFields,
+                                                                                                            altFieldName);
+                                                         if (altMapping != null) {
+                                                           if (checkFieldMapping(value, altMapping)) {
+                                                             return normalizeFieldValueCollectionForMapping(Pair.of(altFieldName,
+                                                                                                                    value),
+                                                                                                            altMapping);
+                                                           }
+                                                           if (ignoredFieldNames.add(altFieldName)) {
+                                                             LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES alternative type '{}'. Ignore adding it in indexed document.",
+                                                                      name,
+                                                                      getFieldMappingType(value),
+                                                                      altMapping.getType());
+                                                           }
+                                                           return null;
                                                          } else if (checkFieldMapping(value, mapping)) {
-                                                           return e;
-                                                         } else if (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
-                                                                    || mapping.getType().equals(TEXT_MAPPING_TYPE)) {
-                                                           String altFieldType = createFieldMapping(altFieldName, value);
-                                                           LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}'",
-                                                                    name,
-                                                                    altFieldName,
-                                                                    mapping.getType(),
-                                                                    altFieldType);
-                                                           return Pair.of(altFieldName, value);
+                                                           return normalizeFieldValueCollectionForMapping(e, mapping);
                                                          } else {
                                                            // Start:: Log the
                                                            // same field
                                                            // only once
-                                                           if (!ignoredFieldNames.contains(name)) {
-                                                             ignoredFieldNames.add(name);
+                                                           if (ignoredFieldNames.add(name)) {
                                                              LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
                                                                       name,
                                                                       getFieldMappingType(value),
@@ -468,37 +477,83 @@ public class ElasticsearchAnalyticsStorage {
     return createRequest.toString() + "\n" + document.toJSON() + "\n";
   }
 
-  private String createFieldMapping(String f, Object value) {
-    String type = getFieldMappingType(value);
-    try {
-      sendPutRequest(elasticsearchConfiguration.getIndexAlias() + "/_mapping", String.format("""
-          {
-            "properties": {
-              "%s" : {
-                "type" : "%s"
-              }
-            }
-          }
-          """, f, type));
-      LOG.info("Create ES Mapping for field '{}' with type '{}'", f, type);
-      listenerService.broadcast(FIELD_MAPPING_CREATED_EVENT, f, type);
-    } catch (Exception e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing.",
-                 f,
-                 type,
-                 e);
-      } else {
-        LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing. Error: {}",
-                 f,
-                 type,
-                 e.getMessage());
-      }
+  private Entry<String, ? extends Object> normalizeFieldValueForMapping(Entry<String, Object> pair,
+                                                                        StatisticFieldMapping mapping) {
+    if (mapping != null
+        && (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
+            || mapping.getType().equals(TEXT_MAPPING_TYPE))
+        && !(pair.getValue() instanceof String)) {
+      return Pair.of(pair.getKey(), pair.getValue().toString());
+    } else {
+      return pair;
     }
-    return type;
   }
 
-  private boolean checkFieldMapping(Object value, StatisticFieldMapping mapping) {
+  private Entry<String, ? extends Collection<Object>> normalizeFieldValueCollectionForMapping(Entry<String, Collection<Object>> pair,
+                                                                                              StatisticFieldMapping mapping) {
+    if (mapping != null
+        && (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
+            || mapping.getType().equals(TEXT_MAPPING_TYPE))
+        && pair.getValue().stream().anyMatch(v -> !(v instanceof String))) {
+      return Pair.of(pair.getKey(),
+                     pair.getValue()
+                         .stream()
+                         .filter(Objects::nonNull)
+                         .map(Object::toString)
+                         .map(Object.class::cast)
+                         .toList());
+    } else {
+      return pair;
+    }
+  }
+
+  private StatisticFieldMapping getFieldMapping(Map<String, StatisticFieldMapping> mappedFields, String name) {
+    if (mappedFields.containsKey(name)) {
+      return mappedFields.get(name);
+    } else if (mappedFieldNames.containsKey(name)) {
+      return new StatisticFieldMapping(name, mappedFieldNames.get(name), false);
+    } else {
+      return null;
+    }
+  }
+
+  private String createFieldMapping(String f, Object value) {
+    String type = getFieldMappingType(value);
+    String existingType = mappedFieldNames.putIfAbsent(f, type);
+    if (existingType == null) {
+      try {
+        sendPutRequest(elasticsearchConfiguration.getIndexAlias() + "/_mapping", String.format("""
+            {
+              "properties": {
+                "%s" : {
+                  "type" : "%s"
+                }
+              }
+            }
+            """, f, type));
+        LOG.info("Create ES Mapping for field '{}' with type '{}'", f, type);
+        sendRefreshIndex();
+        listenerService.broadcast(FIELD_MAPPING_CREATED_EVENT, f, type);
+      } catch (Exception e) {
+        if (LOG.isDebugEnabled()) {
+          LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing.",
+                   f,
+                   type,
+                   e);
+        } else {
+          LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing. Error: {}",
+                   f,
+                   type,
+                   e.getMessage());
+        }
+      }
+      return type;
+    } else {
+      return existingType;
+    }
+  }
+
+  private boolean checkFieldMapping(Object value, StatisticFieldMapping mapping) { // NOSONAR
     if (mapping == null) {
       return true;
     } else {
@@ -507,15 +562,47 @@ public class ElasticsearchAnalyticsStorage {
       if (StringUtils.equalsIgnoreCase(mappedType, fieldMappingType)) {
         return true;
       } else {
-        return switch (fieldMappingType) {
-        case LONG_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(mappedType) || LONG_MAPPING_TYPE.equals(mappedType);
-        case FLOAT_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(mappedType);
-        case BOOLEAN_MAPPING_TYPE -> BOOLEAN_MAPPING_TYPE.equals(mappedType);
-        case KEYWORD_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(mappedType) || TEXT_MAPPING_TYPE.equals(mappedType);
-        case TEXT_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(mappedType) || TEXT_MAPPING_TYPE.equals(mappedType);
+        return switch (mappedType) {
+        case LONG_MAPPING_TYPE -> LONG_MAPPING_TYPE.equals(fieldMappingType)
+                                  || (KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                      && value instanceof String s
+                                      && isLongValue(s));
+        case FLOAT_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(fieldMappingType)
+                                   || LONG_MAPPING_TYPE.equals(fieldMappingType)
+                                   || (KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                       && value instanceof String s
+                                       && isDecimalValue(s));
+        case BOOLEAN_MAPPING_TYPE -> BOOLEAN_MAPPING_TYPE.equals(fieldMappingType)
+                                     || (KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                         && value instanceof String s
+                                         && isBooleanValue(s));
+        case KEYWORD_MAPPING_TYPE, TEXT_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                                        || TEXT_MAPPING_TYPE.equals(fieldMappingType);
         default -> false;
         };
       }
+    }
+  }
+
+  private boolean isBooleanValue(String stringValue) {
+    return StringUtils.equalsAnyIgnoreCase(stringValue, "true", "false");
+  }
+
+  private boolean isLongValue(String value) {
+    try {
+      Long.parseLong(value);
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+
+  private boolean isDecimalValue(String value) {
+    try {
+      new BigDecimal(value);
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
     }
   }
 
@@ -529,7 +616,11 @@ public class ElasticsearchAnalyticsStorage {
     case Float v -> FLOAT_MAPPING_TYPE;
     case Double v -> FLOAT_MAPPING_TYPE;
     case Boolean v -> BOOLEAN_MAPPING_TYPE;
-    case Collection v -> getFieldMappingType(v.toArray()[0]);
+    case Collection v -> ((Collection<?>) v).stream()
+                                            .filter(Objects::nonNull)
+                                            .findFirst()
+                                            .map(this::getFieldMappingType)
+                                            .orElse(KEYWORD_MAPPING_TYPE);
     default -> KEYWORD_MAPPING_TYPE;
     };
   }

--- a/analytics-services/src/main/java/io/meeds/analytics/oauth/util/Utils.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/oauth/util/Utils.java
@@ -101,47 +101,47 @@ public class Utils {
   }
 
   public static void addOAuthClientFields(StatisticData statisticData, RegisteredClient client) {
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, getClientId(client));
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, getClientId(client));
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
+    statisticData.addKeywords(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
     if (CollectionUtils.isNotEmpty(client.getAuthorizationGrantTypes())) {
-      statisticData.addParameter(PARAM_OAUTH_CLIENT_AUTH_METHOD,
-                                 client.getClientAuthenticationMethods()
-                                       .stream()
-                                       .map(ClientAuthenticationMethod::getValue)
-                                       .toList());
+      statisticData.addKeywords(PARAM_OAUTH_CLIENT_AUTH_METHOD,
+                                client.getClientAuthenticationMethods()
+                                      .stream()
+                                      .map(ClientAuthenticationMethod::getValue)
+                                      .toList());
     }
     if (CollectionUtils.isNotEmpty(client.getAuthorizationGrantTypes())) {
-      statisticData.addParameter(PARAM_OAUTH_CLIENT_GRANT_TYPES,
-                                 client.getAuthorizationGrantTypes()
-                                       .stream()
-                                       .map(AuthorizationGrantType::getValue)
-                                       .toList());
+      statisticData.addKeywords(PARAM_OAUTH_CLIENT_GRANT_TYPES,
+                                client.getAuthorizationGrantTypes()
+                                      .stream()
+                                      .map(AuthorizationGrantType::getValue)
+                                      .toList());
     }
     if (CollectionUtils.isNotEmpty(client.getAuthorizationGrantTypes())) {
-      statisticData.addParameter(PARAM_OAUTH_CLIENT_SCOPES,
-                                 client.getScopes()
-                                       .stream()
-                                       .map(s -> PARAM_SCOPE_PREFIX + s)
-                                       .toList());
+      statisticData.addKeywords(PARAM_OAUTH_CLIENT_SCOPES,
+                                client.getScopes()
+                                      .stream()
+                                      .map(s -> PARAM_SCOPE_PREFIX + s)
+                                      .toList());
     }
   }
 
   public static void addOAuthConsentFields(StatisticData statisticData, OAuth2AuthorizationConsent consent) {
-    statisticData.addParameter(PARAM_OAUTH_CONSENT_SCOPES,
-                               consent.getScopes()
-                                      .stream()
-                                      .map(s -> PARAM_SCOPE_PREFIX + s)
-                                      .toList());
+    statisticData.addKeywords(PARAM_OAUTH_CONSENT_SCOPES,
+                              consent.getScopes()
+                                     .stream()
+                                     .map(s -> PARAM_SCOPE_PREFIX + s)
+                                     .toList());
   }
 
   public static void addOAuthTokenFields(StatisticData statisticData, OAuth2Authorization token) {
-    statisticData.addParameter(PARAM_OAUTH_TOKEN_ID, DigestUtils.sha256Hex(token.getId()).substring(0, 16));
-    statisticData.addParameter(PARAM_OAUTH_TOKEN_SCOPES,
-                               token.getAuthorizedScopes()
-                                    .stream()
-                                    .map(s -> PARAM_SCOPE_PREFIX + s)
-                                    .toList());
+    statisticData.addKeyword(PARAM_OAUTH_TOKEN_ID, DigestUtils.sha256Hex(token.getId()).substring(0, 16));
+    statisticData.addKeywords(PARAM_OAUTH_TOKEN_SCOPES,
+                              token.getAuthorizedScopes()
+                                   .stream()
+                                   .map(s -> PARAM_SCOPE_PREFIX + s)
+                                   .toList());
   }
 
   public static String getClientId(RegisteredClient client) {

--- a/analytics-services/src/main/resources/analytics-es-template.json
+++ b/analytics-services/src/main/resources/analytics-es-template.json
@@ -23,10 +23,10 @@
           "format": "epoch_millis"
         },
         "userId": {
-          "type": "long"
+          "type": "keyword"
         },
         "spaceId": {
-          "type": "long"
+          "type": "keyword"
         },
         "module": {
           "type": "keyword"


### PR DESCRIPTION
Avoid creating *_alt Elasticsearch fields when an incoming typed statistic value is incompatible with an already mapped keyword/text field.

Now that statistic producers use explicit typed APIs, mismatches against an existing mapping are treated as producer-side errors: the value is ignored and logged once instead of mutating the ES schema.

Existing *_alt fields remain supported for backward compatibility. New unmapped fields are still mapped normally.