### PR TITLE
fix: prevent automatic alt mapping on typed field mismatch - EXO-87596

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/model/ProductOnlyStackTraceException.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/ProductOnlyStackTraceException.java
@@ -1,0 +1,100 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.analytics.model;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class ProductOnlyStackTraceException extends RuntimeException {
+
+  private static final String BASE_PACKAGE_COM_EXOPLATFORM = "com.exoplatform";
+
+  private static final String BASE_PACKAGE_ORG_EXOPLATFORM = "org.exoplatform";
+
+  private static final String BASE_PACKAGE_IO_MEEDS        = "io.meeds";
+
+  private static final long   serialVersionUID             = 2090796822546017069L;
+
+  private boolean             initialized;                                        // NOSONAR
+
+  @Override
+  public StackTraceElement[] getStackTrace() {
+    initStackTrace();
+    return super.getStackTrace();
+  }
+
+  @Override
+  public void printStackTrace(PrintStream s) {
+    initStackTrace();
+    super.printStackTrace(s);
+  }
+
+  @Override
+  public void printStackTrace(PrintWriter s) {
+    initStackTrace();
+    super.printStackTrace(s);
+  }
+
+  private void initStackTrace() {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+    StackTraceElement[] stackTrace = getStackTrace();
+    List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
+                                                      .filter(trace -> StringUtils.containsAny(trace.getClassName(),
+                                                                                               BASE_PACKAGE_IO_MEEDS,
+                                                                                               BASE_PACKAGE_ORG_EXOPLATFORM,
+                                                                                               BASE_PACKAGE_COM_EXOPLATFORM))
+                                                      .toList();
+    setStackTrace(productStackTrace.toArray(new StackTraceElement[productStackTrace.size()]));
+  }
+
+  @Override
+  public synchronized Throwable initCause(Throwable cause) {
+    StackTraceElement[] stackTrace = getStackTrace();
+    List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
+                                                      .filter(trace -> StringUtils.containsAny(trace.getClassName(),
+                                                                                               BASE_PACKAGE_IO_MEEDS,
+                                                                                               BASE_PACKAGE_ORG_EXOPLATFORM,
+                                                                                               BASE_PACKAGE_COM_EXOPLATFORM))
+                                                      .toList();
+    cause.setStackTrace(productStackTrace.toArray(new StackTraceElement[productStackTrace.size()]));
+    return super.initCause(cause);
+  }
+
+  @Override
+  public synchronized Throwable getCause() {
+    Throwable cause = super.getCause();
+    StackTraceElement[] stackTrace = getStackTrace();
+    List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
+                                                      .filter(trace -> StringUtils.containsAny(trace.getClassName(),
+                                                                                               BASE_PACKAGE_IO_MEEDS,
+                                                                                               BASE_PACKAGE_ORG_EXOPLATFORM,
+                                                                                               BASE_PACKAGE_COM_EXOPLATFORM))
+                                                      .toList();
+    cause.setStackTrace(productStackTrace.toArray(new StackTraceElement[productStackTrace.size()]));
+    return cause;
+  }
+}

--- a/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/StatisticData.java
@@ -20,25 +20,46 @@
 package io.meeds.analytics.model;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.commons.utils.PropertyManager;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Slf4j
 public class StatisticData implements Serializable {
+
+  private static final ZoneId             DEFAULT_ZONE_ID  = ZoneId.systemDefault();
+
+  private static final boolean            DEVELOPPING      = PropertyManager.isDevelopping();
 
   private static final List<Class<?>>     PRIMITIVE_TYPES  = List.of(Boolean.class,
                                                                      Byte.class,
@@ -48,11 +69,22 @@ public class StatisticData implements Serializable {
                                                                      Float.class,
                                                                      Double.class);
 
+  private static final List<Class<?>>     DATE_TYPES       = List.of(Date.class,
+                                                                     Calendar.class,
+                                                                     Instant.class,
+                                                                     ZonedDateTime.class,
+                                                                     OffsetDateTime.class,
+                                                                     LocalDateTime.class,
+                                                                     LocalDate.class);
+
   private static final long               serialVersionUID = -2660993500359866340L;
 
-  private static final int                PRIME            = 59;
+  private static final String             HASH_ALGORITHM   = "SHA-256";
 
   private final String                    uuid             = UUID.randomUUID().toString();
+
+  @ToString.Exclude
+  private transient volatile Long         computedId;
 
   @ToString.Exclude
   private DateFormat                      dateFormat;
@@ -77,16 +109,198 @@ public class StatisticData implements Serializable {
 
   private long                            errorCode;
 
-  private Map<String, Object>             parameters;                                     // NOSONAR
+  private Map<String, Object>             parameters;                                        // NOSONAR
 
-  private Map<String, Collection<Object>> listParameters;                                 // NOSONAR
+  private Map<String, Collection<Object>> listParameters;                                    // NOSONAR
 
-  public void addParameter(String key, Object value) {
+  public enum StatisticStatus {
+    OK, KO;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    return this == o || o instanceof StatisticData other && computeId() == other.computeId();
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(computeId());
+  }
+
+  /**
+   * Add a textual statistic data parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addKeyword(String key, Object value) {
+    if (value != null) {
+      if (value instanceof Collection c) { // NOSONAR
+        addKeywords(key, c);
+      } else {
+        addParameterValue(key, String.valueOf(value));
+      }
+    }
+  }
+
+  /**
+   * Add a textual statistic data list parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addKeywords(String key, Collection<?> value) {
+    if (value == null) {
+      return;
+    }
+    addListParameterValues(key,
+                           value.stream()
+                                .filter(Objects::nonNull)
+                                .map(String::valueOf)
+                                .toList());
+  }
+
+  /**
+   * Add a long statistic data parameter. Used for fields used to aggregate
+   * count, mean, min, max or for timestamp only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addLong(String key, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection c) { // NOSONAR
+      addLongs(key, c);
+      return;
+    }
+    Long longValue = parseLongValue(key, value);
+    if (longValue != null) {
+      addParameterValue(key, longValue);
+    }
+  }
+
+  /**
+   * Add a long statistic data list parameter. Used for fields used to aggregate
+   * count, mean, min, max or for timestamp only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addLongs(String key, Collection<?> value) {
+    if (value != null) {
+      addListParameterValues(key,
+                             value.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(v -> parseLongValue(key, v))
+                                  .filter(Objects::nonNull)
+                                  .toList());
+    }
+  }
+
+  /**
+   * Add a double statistic data parameter. Used for fields used to aggregate
+   * count, mean, min or max only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addDouble(String key, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection c) { // NOSONAR
+      addDoubles(key, c);
+      return;
+    }
+    Double doubleValue = parseDoubleValue(key, value);
+    if (doubleValue != null) {
+      addParameterValue(key, doubleValue);
+    }
+  }
+
+  /**
+   * Add a double statistic data list parameter. Used for fields used to
+   * aggregate count, mean, min or max only
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addDoubles(String key, Collection<?> value) {
+    if (value != null) {
+      addListParameterValues(key,
+                             value.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(v -> parseDoubleValue(key, v))
+                                  .filter(Objects::nonNull)
+                                  .toList());
+    }
+  }
+
+  /**
+   * Add a boolean statistic data parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   */
+  public void addBoolean(String key, Object value) {
+    if (value == null) {
+      return;
+    }
+    if (value instanceof Collection c) { // NOSONAR
+      addBooleans(key, c);
+      return;
+    }
+    Boolean booleanValue = parseBooleanValue(key, value);
+    if (booleanValue != null) {
+      addParameterValue(key, booleanValue);
+    }
+  }
+
+  /**
+   * Add a boolean statistic data list parameter.
+   *
+   * @param key Statistic Field Name
+   * @param value Statistic Field Values
+   */
+  public void addBooleans(String key, Collection<?> value) {
+    if (value != null) {
+      addListParameterValues(key,
+                             value.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(v -> parseBooleanValue(key, v))
+                                  .filter(Objects::nonNull)
+                                  .toList());
+    }
+  }
+
+  public void addDate(String key, Object value) {
+    addLong(key, value);
+  }
+
+  public void addDates(String key, Collection<?> value) {
+    addLongs(key, value);
+  }
+
+  /**
+   * Add a statistic data parameter
+   * 
+   * @param key Statistic Field Name
+   * @param value Statistic Field Value
+   * @deprecated Use addKeyword, addLong, addDouble, addBoolean, or their
+   *             collection variants to avoid ambiguous ES mappings.
+   */
+  @Deprecated(since = "7.2.0")
+  public void addParameter(String key, Object value) { // NOSONAR
     if (parameters == null) {
       parameters = new HashMap<>();
     }
     if (value == null) {
       return;
+    }
+    if (DEVELOPPING || log.isDebugEnabled()) {
+      log.warn("A statistic data field is collected using a deprecated API", new ProductOnlyStackTraceException());
     }
     if (value instanceof Collection) {
       Collection<?> collection = (Collection<?>) value;
@@ -101,6 +315,133 @@ public class StatisticData implements Serializable {
     } else {
       parameters.put(key, getFieldValue(value));
     }
+    resetComputedId();
+  }
+
+  public long computeId() {
+    Long localComputedId = computedId;
+    if (localComputedId == null) {
+      localComputedId = doComputeId();
+      computedId = localComputedId;
+    }
+    return localComputedId;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+    resetComputedId();
+  }
+
+  public void setUserId(long userId) {
+    this.userId = userId;
+    resetComputedId();
+  }
+
+  public void setSpaceId(long spaceId) {
+    this.spaceId = spaceId;
+    resetComputedId();
+  }
+
+  public void setModule(String module) {
+    this.module = module;
+    resetComputedId();
+  }
+
+  public void setSubModule(String subModule) {
+    this.subModule = subModule;
+    resetComputedId();
+  }
+
+  public void setOperation(String operation) {
+    this.operation = operation;
+    resetComputedId();
+  }
+
+  public void setParameters(Map<String, Object> parameters) {
+    this.parameters = parameters;
+    resetComputedId();
+  }
+
+  public void setListParameters(Map<String, Collection<Object>> listParameters) {
+    this.listParameters = listParameters;
+    resetComputedId();
+  }
+
+  private long doComputeId() {
+    byte[] digest = computeDigest(buildIdSource());
+    return ((long) (digest[0] & 0xff) << 56)
+        | ((long) (digest[1] & 0xff) << 48)
+        | ((long) (digest[2] & 0xff) << 40)
+        | ((long) (digest[3] & 0xff) << 32)
+        | ((long) (digest[4] & 0xff) << 24)
+        | ((long) (digest[5] & 0xff) << 16)
+        | ((long) (digest[6] & 0xff) << 8)
+        | ((long) (digest[7] & 0xff)); // NOSONAR
+  }
+
+  private String buildIdSource() {
+    StringBuilder builder = new StringBuilder();
+    appendIdPart(builder, timestamp);
+    appendIdPart(builder, userId);
+    appendIdPart(builder, spaceId);
+    appendIdPart(builder, module);
+    appendIdPart(builder, subModule);
+    appendIdPart(builder, operation);
+    appendMap(builder, parameters);
+    appendMap(builder, listParameters);
+    appendIdPart(builder, uuid);
+    return builder.toString();
+  }
+
+  private void appendMap(StringBuilder builder, Map<String, ?> map) {
+    if (map == null || map.isEmpty()) {
+      appendIdPart(builder, null);
+      return;
+    }
+    builder.append("map{");
+    map.entrySet()
+       .stream()
+       .sorted(Entry.comparingByKey())
+       .forEach(entry -> {
+         appendIdPart(builder, entry.getKey());
+         appendValue(builder, entry.getValue());
+       });
+    builder.append('}');
+  }
+
+  private void appendValue(StringBuilder builder, Object value) {
+    if (value instanceof Collection<?> collection) {
+      builder.append("collection[");
+      collection.stream()
+                .filter(Objects::nonNull)
+                .map(String::valueOf)
+                .sorted()
+                .forEach(item -> appendIdPart(builder, item));
+      builder.append(']');
+    } else {
+      appendIdPart(builder, value);
+    }
+  }
+
+  private void appendIdPart(StringBuilder builder, Object value) {
+    String stringValue = String.valueOf(value);
+    builder.append(stringValue.length())
+           .append(':')
+           .append(stringValue)
+           .append('|');
+  }
+
+  private byte[] computeDigest(String value) {
+    try {
+      return MessageDigest.getInstance(HASH_ALGORITHM)
+                          .digest(value.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Unable to compute statistic data identifier", e);
+    }
+  }
+
+  private void resetComputedId() {
+    computedId = null;
   }
 
   private Object getFieldValue(Object value) {
@@ -117,6 +458,10 @@ public class StatisticData implements Serializable {
     return PRIMITIVE_TYPES.stream().anyMatch(c -> c.isAssignableFrom(value.getClass()));
   }
 
+  private static boolean isDate(Object value) {
+    return DATE_TYPES.stream().anyMatch(c -> c.isAssignableFrom(value.getClass()));
+  }
+
   private DateFormat buildDateFormat() {
     if (dateFormat == null) {
       dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss Z");
@@ -124,33 +469,88 @@ public class StatisticData implements Serializable {
     return dateFormat;
   }
 
-  public enum StatisticStatus {
-    OK, KO;
+  private long toEpochMillis(Object value) {
+    return switch (value) {
+    case Date date -> date.getTime();
+    case Calendar calendar -> calendar.getTimeInMillis();
+    case Instant instant -> instant.toEpochMilli();
+    case ZonedDateTime zonedDateTime -> zonedDateTime.toInstant().toEpochMilli();
+    case OffsetDateTime offsetDateTime -> offsetDateTime.toInstant().toEpochMilli();
+    case LocalDateTime localDateTime -> localDateTime.atZone(DEFAULT_ZONE_ID).toInstant().toEpochMilli();
+    case LocalDate localDate -> localDate.atStartOfDay(DEFAULT_ZONE_ID).toInstant().toEpochMilli();
+    default -> Long.parseLong(String.valueOf(value));
+    };
   }
 
-  public long computeId() {
-    long result = timestamp;
-    result = result * PRIME + (int) (userId >>> 32 ^ userId);
-    result = result * PRIME + (int) (spaceId >>> 32 ^ spaceId);
-    result = result * PRIME + (module == null ? 43 : module.hashCode());
-    result = result * PRIME + (subModule == null ? 43 : subModule.hashCode());
-    result = result * PRIME + (operation == null ? 43 : operation.hashCode());
-    result = result * PRIME + (parameters == null ? 43 : parameters.hashCode());
-    result = result * PRIME + uuid.hashCode();
-    return result;
+  private void addParameterValue(String key, Object value) {
+    if (StringUtils.isBlank(key) || value == null) {
+      return;
+    }
+    if (parameters == null) {
+      parameters = new HashMap<>();
+    }
+    parameters.put(key, value);
+    resetComputedId();
   }
 
-  public boolean equals(final java.lang.Object o) {
-    if (o == this)
-      return true;
-    if (!(o instanceof StatisticData))
-      return false;
-    final StatisticData other = (StatisticData) o;
-    return hashCode() == other.hashCode();
+  private void addListParameterValues(String key, Collection<?> value) {
+    if (StringUtils.isBlank(key) || value == null) {
+      return;
+    }
+    Collection<Object> values = value.stream()
+                                     .filter(Objects::nonNull)
+                                     .map(Object.class::cast)
+                                     .toList();
+    if (values.isEmpty()) {
+      return;
+    }
+    if (listParameters == null) {
+      listParameters = new HashMap<>();
+    }
+    listParameters.put(key, values);
+    resetComputedId();
   }
 
-  public int hashCode() {
-    return (int) computeId();
+  private Long parseLongValue(String key, Object value) {
+    try {
+      return isDate(value) ? toEpochMillis(value) : Long.parseLong(String.valueOf(value));
+    } catch (RuntimeException e) {
+      logInvalidTypedValue(key, value, "long");
+      return null;
+    }
+  }
+
+  private Double parseDoubleValue(String key, Object value) {
+    try {
+      return Double.parseDouble(String.valueOf(value));
+    } catch (RuntimeException e) {
+      logInvalidTypedValue(key, value, "double");
+      return null;
+    }
+  }
+
+  private Boolean parseBooleanValue(String key, Object value) {
+    String stringValue = String.valueOf(value);
+    if (StringUtils.equalsAnyIgnoreCase(stringValue, "true", "false")) {
+      return Boolean.parseBoolean(stringValue);
+    }
+    logInvalidTypedValue(key, value, "boolean");
+    return null; // NOSONAR
+  }
+
+  private void logInvalidTypedValue(String key, Object value, String type) {
+    if (DEVELOPPING || log.isDebugEnabled()) {
+      log.warn("Invalid {} statistic value for field '{}' and value {}. Field will be ignored",
+               type,
+               key,
+               value,
+               new ProductOnlyStackTraceException());
+    } else {
+      log.warn("Invalid {} statistic value for field '{}' and value {}. Field will be ignored",
+               type,
+               key,
+               value);
+    }
   }
 
 }

--- a/analytics-api/src/main/java/io/meeds/analytics/model/filter/AnalyticsPercentageFilter.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/filter/AnalyticsPercentageFilter.java
@@ -164,15 +164,18 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
   }
 
   public AnalyticsFilter computeThresholdFilter() {
-    AnalyticsAggregation xAxisAggregation = getXAxisAggregation();
+    return computeThresholdFilter(null);
+  }
+
+  public AnalyticsFilter computeThresholdFilter(AnalyticsPeriod period) {
+    AnalyticsAggregation xAxisAggregation = period == null ? getXAxisAggregation() : null;
     return new AnalyticsFilter(getTitle(),
                                getTimeZone(),
                                chartType,
                                colors,
-                               getThresholdFilters(),
+                               getThresholdFilters(period),
                                null,
-                               xAxisAggregation == null ? Collections.emptyList()
-                                                        : Collections.singletonList(xAxisAggregation),
+                               xAxisAggregation == null ? Collections.emptyList() : Collections.singletonList(xAxisAggregation),
                                getThresholdYAggregation(),
                                lang,
                                0l,
@@ -180,15 +183,18 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
   }
 
   public AnalyticsFilter computeLimitFilter() {
-    AnalyticsAggregation xAxisAggregation = getXAxisAggregation();
+    return computeLimitFilter(null);
+  }
+
+  public AnalyticsFilter computeLimitFilter(AnalyticsPeriod period) {
+    AnalyticsAggregation xAxisAggregation = period == null ? getXAxisAggregation() : null;
     return new AnalyticsFilter(getTitle(),
                                getTimeZone(),
                                chartType,
                                colors,
-                               getLimitFilters(),
+                               getLimitFilters(period),
                                null,
-                               xAxisAggregation == null ? Collections.emptyList()
-                                                        : Collections.singletonList(xAxisAggregation),
+                               xAxisAggregation == null ? Collections.emptyList() : Collections.singletonList(xAxisAggregation),
                                getLimitYAggregation(),
                                lang,
                                0l,
@@ -200,10 +206,8 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
     LocalDate clonedPeriodDate = periodDate == null ? null : LocalDate.from(periodDate);
     AnalyticsPeriod clonedAnalyticsPeriod = customPeriod == null ? null : customPeriod.clone();
     AnalyticsPercentageItemFilter cloneAnalyticsPercentageItemFilterValue = value == null ? null : value.clone();
-    AnalyticsPercentageItemFilter cloneAnalyticsPercentageItemFilterThreshold = threshold == null ? null
-                                                                                                  : threshold.clone();
-    AnalyticsPercentageLimit clonedAnalyticsPercentageLimit = percentageLimit == null ? null
-                                                                                      : percentageLimit.clone();
+    AnalyticsPercentageItemFilter cloneAnalyticsPercentageItemFilterThreshold = threshold == null ? null : threshold.clone();
+    AnalyticsPercentageLimit clonedAnalyticsPercentageLimit = percentageLimit == null ? null : percentageLimit.clone();
     return new AnalyticsPercentageFilter(getTitle(),
                                          getTimeZone(),
                                          chartType,
@@ -256,12 +260,11 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
 
   private AnalyticsAggregation getLimitYAggregation() {
     return percentageLimit == null
-        || percentageLimit.getAggregation() == null
-        || percentageLimit.getAggregation().getYAxisAggregation() == null
-                                                                          ? null
-                                                                          : percentageLimit.getAggregation()
-                                                                                           .getYAxisAggregation()
-                                                                                           .clone();
+           || percentageLimit.getAggregation() == null
+           || percentageLimit.getAggregation().getYAxisAggregation() == null ? null :
+                                                                             percentageLimit.getAggregation()
+                                                                                            .getYAxisAggregation()
+                                                                                            .clone();
   }
 
   private AnalyticsAggregation getThresholdYAggregation() {
@@ -281,10 +284,10 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
     return filters;
   }
 
-  private List<AnalyticsFieldFilter> getThresholdFilters() {
+  private List<AnalyticsFieldFilter> getThresholdFilters(AnalyticsPeriod period) {
     List<AnalyticsFieldFilter> filters = new ArrayList<>();
 
-    AnalyticsFieldFilter periodFilter = getPeriodFilter(null);
+    AnalyticsFieldFilter periodFilter = getPeriodFilter(period);
     if (periodFilter != null) {
       filters.add(periodFilter);
     }
@@ -294,10 +297,10 @@ public class AnalyticsPercentageFilter extends AbstractAnalyticsFilter {
     return filters;
   }
 
-  private List<AnalyticsFieldFilter> getLimitFilters() {
+  private List<AnalyticsFieldFilter> getLimitFilters(AnalyticsPeriod period) {
     List<AnalyticsFieldFilter> filters = new ArrayList<>();
 
-    AnalyticsFieldFilter periodFilter = getPeriodFilter(null);
+    AnalyticsFieldFilter periodFilter = getPeriodFilter(period);
     if (periodFilter != null) {
       filters.add(periodFilter);
     }

--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -106,6 +106,10 @@ public class AnalyticsUtils {
 
   public static final String            FIELD_TIMESTAMP                  = "timestamp";
 
+  public static final String            ALTERNATIVE_FIELD_SUFFIX         = "_alt";
+
+  public static final int               MAX_ALTERNATIVE_FIELD_COUNT      = 3;
+
   public static final String            FIELD_MODIFIER_USER_SOCIAL_ID    = "modifierSocialId";
 
   public static final String            FIELD_SOCIAL_IDENTITY_ID         = "identityId";
@@ -353,7 +357,7 @@ public class AnalyticsUtils {
     }
 
     addUserStatistics(statisticData);
-    
+
     try {
       StatisticDataQueueService analyticsQueueService = CommonsUtils.getService(StatisticDataQueueService.class);
       analyticsQueueService.put(statisticData);
@@ -442,18 +446,18 @@ public class AnalyticsUtils {
       return;
     }
     statisticData.setSpaceId(Long.parseLong(space.getId()));
-    statisticData.addParameter("parentSpaceId", space.getParentSpaceId());
-    statisticData.addParameter("spaceTemplateId", space.getTemplateId());
-    statisticData.addParameter("spaceCategoryIds", space.getCategoryIds());
-    statisticData.addParameter("spaceVisibility", space.getVisibility());
-    statisticData.addParameter("spaceRegistration", space.getRegistration());
-    statisticData.addParameter("spaceCreatedTime", space.getCreatedTime());
-    statisticData.addParameter("spaceMembersCount", getSize(space.getMembers()));
-    statisticData.addParameter("spaceManagersCount", getSize(space.getManagers()));
-    statisticData.addParameter("spaceRedactorsCount", getSize(space.getRedactors()));
-    statisticData.addParameter("spaceInviteesCount", getSize(space.getInvitedUsers()));
-    statisticData.addParameter("spacePendingCount", getSize(space.getPendingUsers()));
-    statisticData.addParameter("spaceSovereign", space.isSovereign());
+    statisticData.addKeyword("parentSpaceId", space.getParentSpaceId());
+    statisticData.addKeyword("spaceTemplateId", space.getTemplateId());
+    statisticData.addKeyword("spaceCategoryIds", space.getCategoryIds());
+    statisticData.addKeyword("spaceVisibility", space.getVisibility());
+    statisticData.addKeyword("spaceRegistration", space.getRegistration());
+    statisticData.addLong("spaceCreatedTime", space.getCreatedTime());
+    statisticData.addLong("spaceMembersCount", getSize(space.getMembers()));
+    statisticData.addLong("spaceManagersCount", getSize(space.getManagers()));
+    statisticData.addLong("spaceRedactorsCount", getSize(space.getRedactors()));
+    statisticData.addLong("spaceInviteesCount", getSize(space.getInvitedUsers()));
+    statisticData.addLong("spacePendingCount", getSize(space.getPendingUsers()));
+    statisticData.addBoolean("spaceSovereign", space.isSovereign());
   }
 
   public static void addActivityStatisticsData(StatisticData statisticData, ExoSocialActivity activity) {
@@ -463,17 +467,17 @@ public class AnalyticsUtils {
     String activityId = activity.getParentId() == null ? activity.getId() : activity.getParentId();
     String commentId = activity.getParentCommentId() == null ? activity.getId() : activity.getParentCommentId();
     String subCommentId = activity.getParentCommentId() == null ? null : activity.getId();
-    statisticData.addParameter("activityType", getActivityType(activity));
+    statisticData.addKeyword("activityType", getActivityType(activity));
     if (StringUtils.isNotBlank(activityId)) {
-      statisticData.addParameter("activityId", activityId);
+      statisticData.addKeyword("activityId", activityId);
     }
     if (StringUtils.isNotBlank(commentId)) {
       commentId = commentId.replace(ACTIVITY_COMMENT, "");
-      statisticData.addParameter(ACTIVITY_COMMENT, commentId);
+      statisticData.addKeyword(ACTIVITY_COMMENT, commentId);
     }
     if (StringUtils.isNotBlank(subCommentId)) {
       subCommentId = subCommentId.replace(ACTIVITY_COMMENT, "");
-      statisticData.addParameter("subCommentId", subCommentId);
+      statisticData.addKeyword("subCommentId", subCommentId);
     }
   }
 
@@ -486,18 +490,18 @@ public class AnalyticsUtils {
     if (category == null) {
       return;
     }
-    statisticData.addParameter("categoryId", category.getId());
-    statisticData.addParameter("categoryIcon", category.getIcon());
-    statisticData.addParameter("categoryLinkPermissions", category.getLinkPermissions());
-    statisticData.addParameter("categoryCreatorId", category.getCreatorId());
-    statisticData.addParameter("categoryOwnerId", category.getOwnerId());
-    statisticData.addParameter("categoryParentId", category.getParentId());
+    statisticData.addKeyword("categoryId", category.getId());
+    statisticData.addKeyword("categoryIcon", category.getIcon());
+    statisticData.addKeyword("categoryLinkPermissions", category.getLinkPermissions());
+    statisticData.addKeyword("categoryCreatorId", category.getCreatorId());
+    statisticData.addKeyword("categoryOwnerId", category.getOwnerId());
+    statisticData.addKeyword("categoryParentId", category.getParentId());
   }
 
   public static void addCategoryLinkStatistics(StatisticData statisticData, CategoryObject categoryObject) {
-    statisticData.addParameter("categoryObjectType", categoryObject.getType());
-    statisticData.addParameter("categoryObjectId", categoryObject.getId());
-    statisticData.addParameter("categoryObjectParentId", categoryObject.getParentId());
+    statisticData.addKeyword("categoryObjectType", categoryObject.getType());
+    statisticData.addKeyword("categoryObjectId", categoryObject.getId());
+    statisticData.addKeyword("categoryObjectParentId", categoryObject.getParentId());
     if (categoryObject.getSpaceId() > 0) {
       SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
       Space space = spaceService.getSpaceById(categoryObject.getSpaceId());
@@ -509,10 +513,26 @@ public class AnalyticsUtils {
 
   public static void convertToAltFieldName(Supplier<String> supplier, Consumer<String> consumer, Set<String> fieldNames) {
     String fieldName = supplier.get();
-    String altFieldName = fieldName + "_alt";
-    if (fieldNames.contains(altFieldName)) {
-      consumer.accept(altFieldName);
+    if (StringUtils.isBlank(fieldName) || fieldNames == null || fieldNames.isEmpty()) {
+      return;
     }
+    for (int i = MAX_ALTERNATIVE_FIELD_COUNT; i >= 1; i--) {
+      String altFieldName = getAlternativeFieldName(fieldName, i);
+      if (fieldNames.contains(altFieldName)) {
+        consumer.accept(altFieldName);
+        return;
+      }
+    }
+  }
+
+  public static String getAlternativeFieldName(String fieldName, int alternativeIndex) {
+    String baseFieldName = getBaseFieldName(fieldName);
+    return alternativeIndex == 1 ? baseFieldName + ALTERNATIVE_FIELD_SUFFIX :
+                                 baseFieldName + ALTERNATIVE_FIELD_SUFFIX + alternativeIndex;
+  }
+
+  public static String getBaseFieldName(String fieldName) {
+    return fieldName == null ? null : fieldName.replaceFirst(ALTERNATIVE_FIELD_SUFFIX + "\\d*$", "");
   }
 
   private static int getSize(String[] array) {
@@ -557,16 +577,16 @@ public class AnalyticsUtils {
                         Object propertyValue = properties.get(propertyName);
                         if (properties.containsKey(propertyName)) {
                           if (propertyValue instanceof String value) {
-                            statisticData.addParameter(String.join(".", PROFILE_PROPERTIES, propertyName), value);
+                            statisticData.addKeyword(String.join(".", PROFILE_PROPERTIES, propertyName), value);
                           } else if (!property.isHasChildProperties()
-                              && propertyValue instanceof List<?> values) {
+                                     && propertyValue instanceof List<?> values) {
                             @SuppressWarnings("unchecked")
                             List<Map<String, String>> multiValues = (List<Map<String, String>>) values;
                             List<String> valuesList = multiValues.stream()
                                                                  .map(prop -> prop.get("value"))
                                                                  .filter(Objects::nonNull)
                                                                  .toList();
-                            statisticData.addParameter(String.join(".", PROFILE_PROPERTIES, propertyName), valuesList);
+                            statisticData.addKeyword(String.join(".", PROFILE_PROPERTIES, propertyName), valuesList);
                           }
                         }
                       });

--- a/analytics-listeners/src/main/java/io/meeds/analytics/job/SpacesStatisticsCountJob.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/job/SpacesStatisticsCountJob.java
@@ -55,8 +55,8 @@ public class SpacesStatisticsCountJob {
     statisticData.setSubModule("space");
     statisticData.setOperation("spacesCount");
     statisticData.setDuration(System.currentTimeMillis() - startTime);
-    statisticData.addParameter("countType", "allSpaces");
-    statisticData.addParameter("count", allSpacesCount);
+    statisticData.addKeyword("countType", "allSpaces");
+    statisticData.addLong("count", allSpacesCount);
     AnalyticsUtils.addStatisticData(statisticData);
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/job/UsersStatisticsCountJob.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/job/UsersStatisticsCountJob.java
@@ -92,8 +92,8 @@ public class UsersStatisticsCountJob {
     statisticData.setSubModule("account");
     statisticData.setOperation("usersCount");
     statisticData.setDuration(System.currentTimeMillis() - startTime);
-    statisticData.addParameter("countType", countType);
-    statisticData.addParameter("count", count);
+    statisticData.addKeyword("countType", countType);
+    statisticData.addLong("count", count);
     AnalyticsUtils.addStatisticData(statisticData);
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientRegisterErrorListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthClientRegisterErrorListener.java
@@ -83,22 +83,22 @@ public class OAuthClientRegisterErrorListener implements ListenerBase<Object, Ru
   }
 
   private void addOAuthClientFields(StatisticData statisticData, OAuthCimdClientMetadata client) {
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, client.clientId());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_NAME, client.clientName());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.redirectUris());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.tokenEndpointAuthMethod());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.grantTypes());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.responseTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, client.clientId());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_NAME, client.clientName());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.redirectUris());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.tokenEndpointAuthMethod());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.grantTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.responseTypes());
   }
 
   private void addOAuthClientFields(StatisticData statisticData, OidcClientRegistration client) {
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, client.getClientId());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_SCOPES, client.getScopes());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.getTokenEndpointAuthenticationMethod());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.getGrantTypes());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.getResponseTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, client.getClientId());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_SCOPES, client.getScopes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_AUTH_METHOD, client.getTokenEndpointAuthenticationMethod());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_GRANT_TYPES, client.getGrantTypes());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_RESPONSE_TYPES, client.getResponseTypes());
   }
 
 }

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentConsumerListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentConsumerListener.java
@@ -81,7 +81,7 @@ public class OAuthConsentConsumerListener implements ListenerBase<OAuth2Authoriz
       if (client != null) {
         addOAuthClientFields(statisticData, client);
       } else {
-        statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
+        statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
       }
       addOAuthConsentFields(statisticData, consent);
       addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthConsentListener.java
@@ -100,7 +100,7 @@ public class OAuthConsentListener implements ListenerBase<OAuth2AuthorizationCon
         if (client != null) {
           addOAuthClientFields(statisticData, client);
         } else {
-          statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
+          statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, consent.getRegisteredClientId());
         }
         addOAuthConsentFields(statisticData, consent);
         addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenConsumerListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenConsumerListener.java
@@ -88,11 +88,11 @@ public class OAuthTokenConsumerListener implements ListenerBase<OAuth2Authorizat
       if (client != null) {
         addOAuthClientFields(statisticData, client);
       } else {
-        statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, clientId);
+        statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, clientId);
       }
       addOAuthTokenFields(statisticData, token);
       if (tokenType != null) {
-        statisticData.addParameter(PARAM_OAUTH_TOKEN_TYPE, tokenType);
+        statisticData.addKeyword(PARAM_OAUTH_TOKEN_TYPE, tokenType);
       }
       addStatisticData(statisticData);
     }

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/oauth/OAuthTokenListener.java
@@ -100,7 +100,7 @@ public class OAuthTokenListener implements ListenerBase<OAuth2Authorization, OAu
         if (client != null) {
           addOAuthClientFields(statisticData, client);
         } else {
-          statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, token.getRegisteredClientId());
+          statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, token.getRegisteredClientId());
         }
         addOAuthTokenFields(statisticData, token);
         addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/LoginFailedAnalyticsListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/LoginFailedAnalyticsListener.java
@@ -65,7 +65,7 @@ public class LoginFailedAnalyticsListener extends Listener<String, Map<String, S
     statisticData.setUserId(AnalyticsUtils.getUserIdentityId(data.get("user_id")));
     statisticData.setStatus(data.get("status").equals("ko") ? StatisticData.StatisticStatus.KO :
                                                             StatisticData.StatisticStatus.OK);
-    statisticData.addParameter("reason", data.get("reason"));
+    statisticData.addKeyword("reason", data.get("reason"));
     addStatisticData(statisticData);
   }
 }

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/PageAccessListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/PageAccessListener.java
@@ -115,31 +115,31 @@ public class PageAccessListener extends BaseComponentPlugin implements Applicati
       Space space = SpaceUtils.getSpaceByContext();
       addSpaceStatistics(statisticData, space);
 
-      statisticData.addParameter("httpRequestMethod", httpRequest.getMethod());
-      statisticData.addParameter("httpRequestUri", httpRequest.getRequestURI());
-      statisticData.addParameter("httpRequestProtocol", httpRequest.getProtocol());
-      statisticData.addParameter("httpRequestContentType", httpRequest.getContentType());
-      statisticData.addParameter("httpRequestContentLength", httpRequest.getContentLength());
+      statisticData.addKeyword("httpRequestMethod", httpRequest.getMethod());
+      statisticData.addKeyword("httpRequestUri", httpRequest.getRequestURI());
+      statisticData.addKeyword("httpRequestProtocol", httpRequest.getProtocol());
+      statisticData.addKeyword("httpRequestContentType", httpRequest.getContentType());
+      statisticData.addLong("httpRequestContentLength", httpRequest.getContentLength());
 
-      statisticData.addParameter("userLocale", portalRequestContext.getLocale());
-      statisticData.addParameter("portalOwner", portalRequestContext.getPortalOwner());
-      statisticData.addParameter("portalUri", portalRequestContext.getPortalURI());
-      statisticData.addParameter("pageTitle", portalRequestContext.getTitle());
+      statisticData.addKeyword("userLocale", portalRequestContext.getLocale());
+      statisticData.addKeyword("portalOwner", portalRequestContext.getPortalOwner());
+      statisticData.addKeyword("portalUri", portalRequestContext.getPortalURI());
+      statisticData.addKeyword("pageTitle", portalRequestContext.getTitle());
 
       UIPortal uiportal = Util.getUIPortal();
       if (uiportal != null) {
         UserNode node = uiportal.getSelectedUserNode();
         if (node != null) {
-          statisticData.addParameter("pageUri", node.getURI());
-          statisticData.addParameter("pageName", node.getName());
+          statisticData.addKeyword("pageUri", node.getURI());
+          statisticData.addKeyword("pageName", node.getName());
         }
       }
 
       HttpServletResponse httpResponse = portalRequestContext.getResponse();
       if (httpResponse != null) {
-        statisticData.addParameter("httpResponseContentType", httpResponse.getContentType());
-        statisticData.addParameter("httpResponseContentLength", httpResponse.getBufferSize());
-        statisticData.addParameter("httpResponseStatus", httpResponse.getStatus());
+        statisticData.addKeyword("httpResponseContentType", httpResponse.getContentType());
+        statisticData.addLong("httpResponseContentLength", httpResponse.getBufferSize());
+        statisticData.addKeyword("httpResponseStatus", httpResponse.getStatus());
 
         if (httpResponse.getStatus() >= 400) {
           statisticData.setErrorCode(httpResponse.getStatus());

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/UserAnalyticsEventListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/portal/UserAnalyticsEventListener.java
@@ -100,14 +100,14 @@ public class UserAnalyticsEventListener extends UserEventListener {
       statisticData.setOperation(operation);
       statisticData.setDuration(getDuration());
       statisticData.setUserId(getCurrentUserIdentityId());
-      statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(user.getUserName()));
-      statisticData.addParameter("isEnabled", user.isEnabled());
+      statisticData.addKeyword(FIELD_SOCIAL_IDENTITY_ID, getUserIdentityId(user.getUserName()));
+      statisticData.addBoolean("isEnabled", user.isEnabled());
       if (OrganizationService.EXTERNAL_STORE.equals(user.getOriginatingStore())) {
-        statisticData.addParameter("userSource", EXTERNAL_USER_SOURCE);
+        statisticData.addKeyword("userSource", EXTERNAL_USER_SOURCE);
       } else {
-        statisticData.addParameter("userSource", user.getCreationSource());
+        statisticData.addKeyword("userSource", user.getCreationSource());
       }
-      statisticData.addParameter("modificationSource", UserModificationSource.getSourceOrDefault("ui"));
+      statisticData.addKeyword("modificationSource", UserModificationSource.getSourceOrDefault("ui"));
       return statisticData;
     } catch (Exception e) {
       LOG.warn("Error building analytics Queue entry for operation {}", operation, e);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityListener.java
@@ -175,7 +175,7 @@ public class AnalyticsActivityListener extends ActivityListenerPlugin {
     String[] likeIdentityIds = event.getActivity().getLikeIdentityIds();
     if (likeIdentityIds != null && likeIdentityIds.length > 0) {
       String likerId = likeIdentityIds[likeIdentityIds.length - 1];
-      statisticData.addParameter("likeIdentityId", likerId);
+      statisticData.addKeyword("likeIdentityId", likerId);
     }
   }
 
@@ -229,7 +229,7 @@ public class AnalyticsActivityListener extends ActivityListenerPlugin {
         Space space = spaceService.getSpaceByPrettyName(streamIdentity.getRemoteId());
         addSpaceStatistics(statisticData, space);
       }
-      statisticData.addParameter("streamIdentityId", streamIdentity.getIdentityId());
+      statisticData.addKeyword("streamIdentityId", streamIdentity.getIdentityId());
     }
 
     statisticData.setModule("social");

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityTagsListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsActivityTagsListener.java
@@ -87,10 +87,10 @@ public class AnalyticsActivityTagsListener extends Listener<TagObject, Set<TagNa
     statisticData.setOperation("Add tag");
     statisticData.setTimestamp(new Date().getTime());
     statisticData.setUserId(Long.parseLong(activity.getUserId()));
-    statisticData.addParameter("username", username);
-    statisticData.addParameter("type", objectType);
-    statisticData.addParameter("dataType", StringUtils.lowerCase(objectType));
-    statisticData.addParameter("spaceIdentityId", audienceIdentity.getIdentityId());
+    statisticData.addKeyword("username", username);
+    statisticData.addKeyword("type", objectType);
+    statisticData.addKeyword("dataType", StringUtils.lowerCase(objectType));
+    statisticData.addKeyword("spaceIdentityId", audienceIdentity.getIdentityId());
 
     for (int i = 0; i < numberOfTags; i++) {
       AnalyticsUtils.addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsProfileListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsProfileListener.java
@@ -65,8 +65,8 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
       if (avatarAttachment != null) {
         StatisticData statisticData = buildStatisticData(AVATAR, event.getSource());
         if (statisticData != null) {
-          statisticData.addParameter(IMAGE_SIZE, avatarAttachment.getSize());
-          statisticData.addParameter(IMAGE_TYPE, avatarAttachment.getMimeType());
+          statisticData.addLong(IMAGE_SIZE, avatarAttachment.getSize());
+          statisticData.addKeyword(IMAGE_TYPE, avatarAttachment.getMimeType());
           addStatisticData(statisticData);
         }
       }
@@ -132,8 +132,8 @@ public class AnalyticsProfileListener extends ProfileListenerPlugin {
     statisticData.setSubModule("profile");
     statisticData.setOperation(operation);
     statisticData.setUserId(Long.parseLong(identity.getId()));
-    statisticData.addParameter(FIELD_SOCIAL_IDENTITY_ID, identity.getIdentityId());
-    statisticData.addParameter("userCreatedDate", identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
+    statisticData.addKeyword(FIELD_SOCIAL_IDENTITY_ID, identity.getIdentityId());
+    statisticData.addLong("userCreatedDate", identity.getProfile() != null ? identity.getProfile().getCreatedTime() : 0);
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsRelationshipListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsRelationshipListener.java
@@ -121,8 +121,8 @@ public class AnalyticsRelationshipListener extends RelationshipListenerPlugin {
     statisticData.setSubModule("relationship");
     statisticData.setOperation(operation);
     statisticData.setUserId(getCurrentUserIdentityId());
-    statisticData.addParameter("from", from);
-    statisticData.addParameter("to", to);
+    statisticData.addKeyword("from", from);
+    statisticData.addKeyword("to", to);
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceListener.java
@@ -225,7 +225,7 @@ public class AnalyticsSpaceListener extends SpaceListenerPlugin {
     statisticData.setOperation("joinedByInvitationLink");
     statisticData.setSpaceId(space.getSpaceId());
     statisticData.setUserId(getUserIdentityId(event.getSource()));
-    statisticData.addParameter("inviterId", getUserIdentityId(event.getInviterId()));
+    statisticData.addKeyword("inviterId", getUserIdentityId(event.getInviterId()));
     return statisticData;
   }
 

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/social/AnalyticsSpaceWebNotificationListener.java
@@ -89,15 +89,15 @@ public class AnalyticsSpaceWebNotificationListener extends Listener<SpaceWebNoti
       return;
     }
     if (StringUtils.isNotBlank(spaceWebNotificationItem.getApplicationName())) {
-      statisticData.addParameter("entityType", spaceWebNotificationItem.getApplicationName());
+      statisticData.addKeyword("entityType", spaceWebNotificationItem.getApplicationName());
     }
     if (StringUtils.isNotBlank(spaceWebNotificationItem.getApplicationItemId())) {
-      statisticData.addParameter("entityId", spaceWebNotificationItem.getApplicationItemId());
+      statisticData.addKeyword("entityId", spaceWebNotificationItem.getApplicationItemId());
     }
     if (spaceWebNotificationItem instanceof SpaceWebNotificationItemUpdate spaceWebNotificationItemUpdate) {
       String userEvent = spaceWebNotificationItemUpdate.getUserEvent();
       if (StringUtils.isNotBlank(userEvent)) {
-        statisticData.addParameter("event-type", userEvent);
+        statisticData.addKeyword("event-type", userEvent);
       }
     }
     addStatisticData(statisticData);

--- a/analytics-listeners/src/main/java/io/meeds/analytics/listener/websocket/WebSocketUIStatisticListener.java
+++ b/analytics-listeners/src/main/java/io/meeds/analytics/listener/websocket/WebSocketUIStatisticListener.java
@@ -130,9 +130,9 @@ public class WebSocketUIStatisticListener extends Listener<AnalyticsWebSocketSer
       String dataParameterValue = dataParameter.getValue();
       if (StringUtils.contains(dataParameterValue, ",")) {
         List<String> dataParameterValues = Arrays.asList(StringUtils.split(dataParameterValue, ","));
-        statisticData.addParameter(dataParameterName, dataParameterValues);
+        statisticData.addKeywords(dataParameterName, dataParameterValues);
       } else {
-        statisticData.addParameter(dataParameterName, dataParameterValue);
+        statisticData.addKeyword(dataParameterName, dataParameterValue);
       }
     }
     addStatisticData(statisticData);

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/service/ElasticsearchAnalyticsService.java
@@ -19,6 +19,15 @@
  */
 package io.meeds.analytics.elasticsearch.service;
 
+import static io.meeds.analytics.utils.AnalyticsUtils.DEFAULT_FIELDS;
+import static io.meeds.analytics.utils.AnalyticsUtils.FIELD_TIMESTAMP;
+import static io.meeds.analytics.utils.AnalyticsUtils.collectionToJSONString;
+import static io.meeds.analytics.utils.AnalyticsUtils.fixJSONStringFormat;
+import static io.meeds.analytics.utils.AnalyticsUtils.fromJsonString;
+import static io.meeds.analytics.utils.AnalyticsUtils.getJsonNode;
+import static io.meeds.analytics.utils.AnalyticsUtils.sortByAnalyticsDate;
+import static io.meeds.analytics.utils.AnalyticsUtils.toJsonString;
+
 import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -37,8 +46,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -47,6 +54,9 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
@@ -89,8 +99,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.Getter;
 import lombok.Synchronized;
-
-import static io.meeds.analytics.utils.AnalyticsUtils.*;
 
 @Service
 public class ElasticsearchAnalyticsService implements AnalyticsService {
@@ -305,12 +313,27 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
                                        false);
     }
 
-    computePercentageValuesPerPeriod(percentageChartResult,
-                                     percentageFilter.computeThresholdFilter(),
-                                     currentPeriod,
-                                     previousPeriod,
-                                     false,
-                                     false);
+    if (percentageFilter.getAnalyticsPeriodType() != null || percentageFilter.getCustomPeriod() == null) {
+      computePercentageValuesPerPeriod(percentageChartResult,
+                                       percentageFilter.computeThresholdFilter(),
+                                       currentPeriod,
+                                       previousPeriod,
+                                       false,
+                                       false);
+    } else {
+      computePercentageValuesPerPeriod(percentageChartResult,
+                                       percentageFilter.computeThresholdFilter(currentPeriod),
+                                       currentPeriod,
+                                       null,
+                                       false,
+                                       false);
+      computePercentageValuesPerPeriod(percentageChartResult,
+                                       percentageFilter.computeThresholdFilter(previousPeriod),
+                                       null,
+                                       previousPeriod,
+                                       false,
+                                       false);
+    }
     return percentageChartResult;
   }
 
@@ -756,6 +779,10 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
   private void appendAggregationNameQuery(StringBuilder esQuery,
                                           String aggregationFieldName,
                                           StatisticFieldMapping aggregationField) {
+    if (StringUtils.isBlank(aggregationFieldName)) {
+      aggregationFieldName = FIELD_TIMESTAMP;
+    }
+
     if (aggregationField == null || !aggregationField.isScriptedField()) {
       esQuery.append("""
                     "field": "$aggFieldName"
@@ -927,15 +954,35 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
                                        AnalyticsPeriod currentPeriod,
                                        AnalyticsPeriod previousPeriod) {
     AnalyticsPercentageLimit percentageLimit = percentageFilter.getPercentageLimit();
-    PercentageChartValue chartValue = computePercentageChartData(percentageFilter.computeLimitFilter(),
-                                                                 currentPeriod,
-                                                                 previousPeriod,
-                                                                 false);
+    PercentageChartValue chartValue;
+
+    if (percentageFilter.getAnalyticsPeriodType() != null || percentageFilter.getCustomPeriod() == null) {
+      chartValue = computePercentageChartData(percentageFilter.computeLimitFilter(),
+                                              currentPeriod,
+                                              previousPeriod,
+                                              false);
+    } else {
+      PercentageChartValue currentChartValue = computePercentageChartData(percentageFilter.computeLimitFilter(currentPeriod),
+                                                                          currentPeriod,
+                                                                          null,
+                                                                          false);
+      PercentageChartValue previousChartValue = computePercentageChartData(percentageFilter.computeLimitFilter(previousPeriod),
+                                                                           null,
+                                                                           previousPeriod,
+                                                                           false);
+      chartValue = new PercentageChartValue();
+      chartValue.setCurrentPeriodValue(currentChartValue.getCurrentPeriodValue());
+      chartValue.setPreviousPeriodValue(previousChartValue.getPreviousPeriodValue());
+      chartValue.setComputingTime(currentChartValue.getComputingTime() + previousChartValue.getComputingTime());
+      chartValue.setDataCount(currentChartValue.getDataCount() + previousChartValue.getDataCount());
+    }
 
     double currentPeriodLimit = chartValue.getCurrentPeriodValue();
     double previousPeriodLimit = chartValue.getPreviousPeriodValue();
     percentageChartResult.setCurrentPeriodLimit(currentPeriodLimit);
     percentageChartResult.setPreviousPeriodLimit(previousPeriodLimit);
+    percentageChartResult.setComputingTime(percentageChartResult.getComputingTime() + chartValue.getComputingTime());
+    percentageChartResult.setDataCount(percentageChartResult.getDataCount() + chartValue.getDataCount());
 
     percentageFilter.setCurrentPeriodLimit(Math.round(currentPeriodLimit * percentageLimit.getPercentage() / 100));
     percentageFilter.setPreviousPeriodLimit(Math.round(previousPeriodLimit * percentageLimit.getPercentage() / 100));
@@ -952,15 +999,19 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
                                                                  previousPeriod,
                                                                  hasLimitAggregation);
     if (isValue) {
-      if (chartValue.getCurrentPeriodValue() > 0) {
+      if (currentPeriod != null) {
         percentageResult.setCurrentPeriodValue(chartValue.getCurrentPeriodValue());
       }
-      if (chartValue.getPreviousPeriodValue() > 0) {
+      if (previousPeriod != null) {
         percentageResult.setPreviousPeriodValue(chartValue.getPreviousPeriodValue());
       }
     } else {
-      percentageResult.setCurrentPeriodThreshold(chartValue.getCurrentPeriodValue());
-      percentageResult.setPreviousPeriodThreshold(chartValue.getPreviousPeriodValue());
+      if (currentPeriod != null) {
+        percentageResult.setCurrentPeriodThreshold(chartValue.getCurrentPeriodValue());
+      }
+      if (previousPeriod != null) {
+        percentageResult.setPreviousPeriodThreshold(chartValue.getPreviousPeriodValue());
+      }
     }
     percentageResult.setComputingTime(percentageResult.getComputingTime() + chartValue.getComputingTime());
     percentageResult.setDataCount(percentageResult.getDataCount() + chartValue.getDataCount());
@@ -1102,6 +1153,14 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
       } else if (previousPeriod != null) {
         percentageChartValue.setPreviousPeriodValue(valueDouble);
       }
+    } else if (aggregations.has(AGGREGATION_RESULT_VALUE_PARAM)) {
+      String value = toString(aggregations.getJSONObject(AGGREGATION_RESULT_VALUE_PARAM).get(VALUE_PARAM));
+      double valueDouble = StringUtils.isBlank(value) || StringUtils.equals("null", value) ? 0d : Double.parseDouble(value);
+      if (currentPeriod != null) {
+        percentageChartValue.setCurrentPeriodValue(valueDouble);
+      } else if (previousPeriod != null) {
+        percentageChartValue.setPreviousPeriodValue(valueDouble);
+      }
     } else if (aggregations.has(AGGREGATION_RESULT_PARAM)) {
       JSONArray buckets = aggregations.getJSONObject(AGGREGATION_RESULT_PARAM).getJSONArray(BUCKETS_RESPONSE_BODY);
       Map<Long, Double> values = new HashMap<>();
@@ -1131,9 +1190,8 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
                                                      && timestamp >= currentPeriod.getFromInMS();
 
                                             })
-                                            .map(Map.Entry::getValue)
-                                            .findFirst()
-                                            .orElse(0d);
+                                            .mapToDouble(Map.Entry::getValue)
+                                            .sum();
           percentageChartValue.setCurrentPeriodValue(currentPeriodValue);
         }
 
@@ -1146,9 +1204,8 @@ public class ElasticsearchAnalyticsService implements AnalyticsService {
                                                       && timestamp >= previousPeriod.getFromInMS();
 
                                              })
-                                             .map(Map.Entry::getValue)
-                                             .findFirst()
-                                             .orElse(0d);
+                                             .mapToDouble(Map.Entry::getValue)
+                                             .sum();
           percentageChartValue.setPreviousPeriodValue(previousPeriodValue);
         }
       }

--- a/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/elasticsearch/storage/ElasticsearchAnalyticsStorage.java
@@ -38,9 +38,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +46,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -91,27 +90,33 @@ import lombok.SneakyThrows;
 @Component
 public class ElasticsearchAnalyticsStorage {
 
-  private static final String           TEXT_MAPPING_TYPE    = "text";
+  private static final String           TEXT_MAPPING_TYPE           = "text";
 
-  private static final String           KEYWORD_MAPPING_TYPE = "keyword";
+  private static final String           KEYWORD_MAPPING_TYPE        = "keyword";
 
-  private static final String           BOOLEAN_MAPPING_TYPE = "boolean";
+  private static final String           BOOLEAN_MAPPING_TYPE        = "boolean";
 
-  private static final String           FLOAT_MAPPING_TYPE   = "float";
+  private static final String           FLOAT_MAPPING_TYPE          = "float";
 
-  private static final String           LONG_MAPPING_TYPE    = "long";
+  private static final String           LONG_MAPPING_TYPE           = "long";
 
-  private static final Log              LOG                  =
+  private static final String           ALTERNATIVE_FIELD_SUFFIX    = "_alt";
+
+  private static final int              MAX_ALTERNATIVE_FIELD_COUNT = 3;
+
+  private static final Log              LOG                         =
                                             ExoLogger.getExoLogger(ElasticsearchAnalyticsStorage.class);
 
-  private static final long             DAY_IN_MS            = 86400000L;
+  private static final long             DAY_IN_MS                   = 86400000L;
 
-  private static final String           DAY_DATE_FORMAT      = "yyyy-MM-dd";
+  private static final String           DAY_DATE_FORMAT             = "yyyy-MM-dd";
 
-  public static final DateTimeFormatter DAY_DATE_FORMATTER   = DateTimeFormatter.ofPattern(DAY_DATE_FORMAT)
-                                                                                .withResolverStyle(ResolverStyle.LENIENT);
+  public static final DateTimeFormatter DAY_DATE_FORMATTER          = DateTimeFormatter.ofPattern(DAY_DATE_FORMAT)
+                                                                                       .withResolverStyle(ResolverStyle.LENIENT);
 
-  private List<String>                  ignoredFieldNames    = Collections.synchronizedList(new ArrayList<>());
+  private Set<String>                   ignoredFieldNames           = ConcurrentHashMap.newKeySet();
+
+  private Map<String, String>           mappedFieldNames            = new ConcurrentHashMap<>();
 
   @Autowired
   private ListenerService               listenerService;
@@ -364,7 +369,7 @@ public class ElasticsearchAnalyticsStorage {
       data.getParameters()
           .keySet()
           .stream()
-          .filter(p -> !mappedFields.containsKey(p))
+          .filter(p -> getFieldMapping(mappedFields, p) == null)
           .forEach(f -> createFieldMapping(f, data.getParameters().get(f)));
       Map<String, String> parameters = data.getParameters()
                                            .entrySet()
@@ -373,35 +378,14 @@ public class ElasticsearchAnalyticsStorage {
                                            .map(e -> {
                                              String name = e.getKey();
                                              Object value = e.getValue();
-                                             StatisticFieldMapping mapping = mappedFields.get(name);
-                                             String altFieldName = "%s_alt".formatted(name);
-                                             if (mappedFields.containsKey(altFieldName)) {
-                                               return Pair.of(altFieldName, value);
-                                             } else if (checkFieldMapping(value, mapping)) {
-                                               return e;
-                                             } else if (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
-                                                        || mapping.getType().equals(TEXT_MAPPING_TYPE)) {
-                                               String altFieldType = createFieldMapping(altFieldName, value);
-                                               LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}'",
-                                                        name,
-                                                        altFieldName,
-                                                        mapping.getType(),
-                                                        altFieldType);
-                                               return Pair.of(altFieldName, value);
-                                             } else {
-                                               // Start:: Log the same field
-                                               // only once
-                                               if (!ignoredFieldNames.contains(name)) {
-                                                 ignoredFieldNames.add(name);
-                                                 LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
-                                                          name,
-                                                          getFieldMappingType(value),
-                                                          mapping.getType());
-                                               }
-                                               // End:: Log the same field only
-                                               // once
+                                             if (value == null) {
                                                return null;
                                              }
+                                             StatisticFieldMapping mapping = getFieldMapping(mappedFields, name);
+                                             return normalizeFieldValueForMapping(mappedFields,
+                                                                                  e,
+                                                                                  mapping,
+                                                                                  data.getParameters());
                                            })
                                            .filter(Objects::nonNull)
                                            .collect(Collectors.toMap(Entry::getKey, e -> getFieldValue(e.getValue())));
@@ -416,7 +400,7 @@ public class ElasticsearchAnalyticsStorage {
       data.getListParameters()
           .keySet()
           .stream()
-          .filter(p -> !mappedFields.containsKey(p))
+          .filter(p -> getFieldMapping(mappedFields, p) == null)
           .filter(p -> CollectionUtils.isNotEmpty(data.getListParameters().get(p)))
           .forEach(p -> createFieldMapping(p, data.getListParameters().get(p)));
       Map<String, Collection<String>> parameters = data.getListParameters()
@@ -424,39 +408,11 @@ public class ElasticsearchAnalyticsStorage {
                                                        .stream()
                                                        .filter(e -> CollectionUtils.isNotEmpty(e.getValue()))
                                                        .map(e -> {
-                                                         Collection<Object> value = e.getValue();
                                                          String name = e.getKey();
-                                                         StatisticFieldMapping mapping = mappedFields.get(name);
-                                                         String altFieldName = "%s_alt".formatted(name);
-                                                         if (mappedFields.containsKey(altFieldName)) {
-                                                           return Pair.of(altFieldName, value);
-                                                         } else if (checkFieldMapping(value, mapping)) {
-                                                           return e;
-                                                         } else if (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
-                                                                    || mapping.getType().equals(TEXT_MAPPING_TYPE)) {
-                                                           String altFieldType = createFieldMapping(altFieldName, value);
-                                                           LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}'",
-                                                                    name,
-                                                                    altFieldName,
-                                                                    mapping.getType(),
-                                                                    altFieldType);
-                                                           return Pair.of(altFieldName, value);
-                                                         } else {
-                                                           // Start:: Log the
-                                                           // same field
-                                                           // only once
-                                                           if (!ignoredFieldNames.contains(name)) {
-                                                             ignoredFieldNames.add(name);
-                                                             LOG.warn("Field with name '{}' and type '{}' isn't compatible with ES type '{}'. Ignore adding it in indexed document.",
-                                                                      name,
-                                                                      getFieldMappingType(value),
-                                                                      mapping.getType());
-                                                           }
-                                                           // End:: Log the same
-                                                           // field only
-                                                           // once
-                                                           return null;
-                                                         }
+                                                         StatisticFieldMapping mapping = getFieldMapping(mappedFields, name);
+                                                         return normalizeFieldValueCollectionForMapping(mappedFields,
+                                                                                                        e,
+                                                                                                        mapping);
                                                        })
                                                        .filter(Objects::nonNull)
                                                        .collect(Collectors.toMap(Entry::getKey,
@@ -468,37 +424,217 @@ public class ElasticsearchAnalyticsStorage {
     return createRequest.toString() + "\n" + document.toJSON() + "\n";
   }
 
-  private String createFieldMapping(String f, Object value) {
-    String type = getFieldMappingType(value);
-    try {
-      sendPutRequest(elasticsearchConfiguration.getIndexAlias() + "/_mapping", String.format("""
-          {
-            "properties": {
-              "%s" : {
-                "type" : "%s"
-              }
-            }
-          }
-          """, f, type));
-      LOG.info("Create ES Mapping for field '{}' with type '{}'", f, type);
-      listenerService.broadcast(FIELD_MAPPING_CREATED_EVENT, f, type);
-    } catch (Exception e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing.",
-                 f,
-                 type,
-                 e);
-      } else {
-        LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing. Error: {}",
-                 f,
-                 type,
-                 e.getMessage());
-      }
+  private Entry<String, ? extends Object> normalizeFieldValueForMapping(Map<String, StatisticFieldMapping> mappedFields,
+                                                                        Entry<String, Object> pair,
+                                                                        StatisticFieldMapping originalMapping,
+                                                                        Map<String, Object> parameters) {
+    String name = pair.getKey();
+    Object value = pair.getValue();
+    StatisticFieldMapping latestAltMapping = getLatestAlternativeFieldMapping(mappedFields, name);
+    if (latestAltMapping != null) {
+      return normalizeAlternativeFieldValueForMapping(name, value, latestAltMapping, parameters);
+    } else if (checkFieldMapping(value, originalMapping)) {
+      return normalizeFieldValueForMapping(pair, originalMapping);
+    } else {
+      return createAlternativeFieldValueForMapping(originalMapping, name, value, 1);
     }
-    return type;
   }
 
-  private boolean checkFieldMapping(Object value, StatisticFieldMapping mapping) {
+  private Entry<String, ? extends Collection<Object>> normalizeFieldValueCollectionForMapping(Map<String, StatisticFieldMapping> mappedFields,
+                                                                                              Entry<String, Collection<Object>> pair,
+                                                                                              StatisticFieldMapping originalMapping) {
+    String name = pair.getKey();
+    Collection<Object> value = pair.getValue();
+    StatisticFieldMapping latestAltMapping = getLatestAlternativeFieldMapping(mappedFields, name);
+    if (latestAltMapping != null) {
+      return normalizeAlternativeFieldValueCollectionForMapping(name, value, latestAltMapping);
+    } else if (checkFieldMapping(value, originalMapping)) {
+      return normalizeFieldValueCollectionForMapping(pair, originalMapping);
+    } else {
+      return createAlternativeFieldValueCollectionForMapping(latestAltMapping, name, value, 1);
+    }
+  }
+
+  private Entry<String, ? extends Object> normalizeAlternativeFieldValueForMapping(String name,
+                                                                                   Object value,
+                                                                                   StatisticFieldMapping latestAltMapping,
+                                                                                   Map<String, Object> parameters) {
+    if (checkFieldMapping(value, latestAltMapping)) {
+      return normalizeFieldValueForMapping(Pair.of(latestAltMapping.getName(), value), latestAltMapping);
+    }
+    int nextAlternativeIndex = getAlternativeFieldIndex(latestAltMapping.getName()) + 1;
+    if (nextAlternativeIndex <= MAX_ALTERNATIVE_FIELD_COUNT) {
+      return createAlternativeFieldValueForMapping(latestAltMapping, name, value, nextAlternativeIndex);
+    }
+    if (ignoredFieldNames.add(name)) {
+      LOG.warn("Field with name '{}' and type '{}' isn't compatible with latest ES alternative field '{}' of type '{}'. All alternative fields are unavailable. Ignore adding it in indexed document {}",
+               name,
+               getFieldMappingType(value),
+               latestAltMapping.getName(),
+               latestAltMapping.getType(),
+               parameters);
+    }
+    return null;
+  }
+
+  private Entry<String, ? extends Collection<Object>> normalizeAlternativeFieldValueCollectionForMapping(String name,
+                                                                                                         Collection<Object> value,
+                                                                                                         StatisticFieldMapping latestAltMapping) {
+    if (checkFieldMapping(value, latestAltMapping)) {
+      return normalizeFieldValueCollectionForMapping(Pair.of(latestAltMapping.getName(), value), latestAltMapping);
+    }
+    int nextAlternativeIndex = getAlternativeFieldIndex(latestAltMapping.getName()) + 1;
+    if (nextAlternativeIndex <= MAX_ALTERNATIVE_FIELD_COUNT) {
+      return createAlternativeFieldValueCollectionForMapping(latestAltMapping, name, value, nextAlternativeIndex);
+    }
+    if (ignoredFieldNames.add(name)) {
+      LOG.warn("Field with name '{}' and type '{}' isn't compatible with latest ES alternative field '{}' of type '{}'. All alternative fields are unavailable. Ignore adding it in indexed document.",
+               name,
+               getFieldMappingType(value),
+               latestAltMapping.getName(),
+               latestAltMapping.getType());
+    }
+    return null;
+  }
+
+  private Entry<String, ? extends Object> createAlternativeFieldValueForMapping(StatisticFieldMapping existingMapping,
+                                                                                String name,
+                                                                                Object value,
+                                                                                int alternativeIndex) {
+    String altFieldName = getAlternativeFieldName(name, alternativeIndex);
+    String altFieldType = createFieldMapping(altFieldName, value);
+    LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}' (value = '{}')",
+             existingMapping.getName(),
+             altFieldName,
+             existingMapping.getType(),
+             altFieldType,
+             value);
+    StatisticFieldMapping createdAltMapping = new StatisticFieldMapping(altFieldName, altFieldType, false);
+    return normalizeFieldValueForMapping(Pair.of(altFieldName, value), createdAltMapping);
+  }
+
+  private Entry<String, ? extends Collection<Object>> createAlternativeFieldValueCollectionForMapping(StatisticFieldMapping existingMapping,
+                                                                                                      String name,
+                                                                                                      Collection<Object> value,
+                                                                                                      int alternativeIndex) {
+    String altFieldName = getAlternativeFieldName(name, alternativeIndex);
+    String altFieldType = createFieldMapping(altFieldName, value);
+    LOG.warn("ES Field '{}' will be renamed to '{}' due to different type: ES Type = '{}', detected type = '{}' (list of value = '{}')",
+             existingMapping.getName(),
+             altFieldName,
+             existingMapping.getType(),
+             altFieldType,
+             StringUtils.join(value, ","));
+    StatisticFieldMapping createdAltMapping = new StatisticFieldMapping(altFieldName, altFieldType, false);
+    return normalizeFieldValueCollectionForMapping(Pair.of(altFieldName, value), createdAltMapping);
+  }
+
+  private StatisticFieldMapping getLatestAlternativeFieldMapping(Map<String, StatisticFieldMapping> mappedFields, String name) {
+    StatisticFieldMapping latestAltMapping = null;
+    for (int i = 1; i <= MAX_ALTERNATIVE_FIELD_COUNT; i++) {
+      StatisticFieldMapping altMapping = getFieldMapping(mappedFields, getAlternativeFieldName(name, i));
+      if (altMapping != null) {
+        latestAltMapping = altMapping;
+      }
+    }
+    return latestAltMapping;
+  }
+
+  private int getAlternativeFieldIndex(String name) {
+    if (!StringUtils.contains(name, ALTERNATIVE_FIELD_SUFFIX)) {
+      return 0;
+    }
+    String index = StringUtils.substringAfterLast(name, ALTERNATIVE_FIELD_SUFFIX);
+    return StringUtils.isBlank(index) ? 1 : Integer.parseInt(index);
+  }
+
+  private String getAlternativeFieldName(String name, int alternativeIndex) {
+    String baseName = getBaseFieldName(name);
+    return alternativeIndex == 1 ? "%s%s".formatted(baseName, ALTERNATIVE_FIELD_SUFFIX) :
+                                 "%s%s%s".formatted(baseName, ALTERNATIVE_FIELD_SUFFIX, alternativeIndex);
+  }
+
+  private String getBaseFieldName(String name) {
+    return name == null ? null : name.replaceFirst("%s\\d*$".formatted(ALTERNATIVE_FIELD_SUFFIX), "");
+  }
+
+  private Entry<String, ? extends Object> normalizeFieldValueForMapping(Entry<String, Object> pair,
+                                                                        StatisticFieldMapping mapping) {
+    if (mapping != null
+        && (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
+            || mapping.getType().equals(TEXT_MAPPING_TYPE))
+        && !(pair.getValue() instanceof String)) {
+      return Pair.of(pair.getKey(), pair.getValue().toString());
+    } else {
+      return pair;
+    }
+  }
+
+  private Entry<String, ? extends Collection<Object>> normalizeFieldValueCollectionForMapping(Entry<String, Collection<Object>> pair,
+                                                                                              StatisticFieldMapping mapping) {
+    if (mapping != null
+        && (mapping.getType().equals(KEYWORD_MAPPING_TYPE)
+            || mapping.getType().equals(TEXT_MAPPING_TYPE))
+        && pair.getValue().stream().anyMatch(v -> !(v instanceof String))) {
+      return Pair.of(pair.getKey(),
+                     pair.getValue()
+                         .stream()
+                         .filter(Objects::nonNull)
+                         .map(Object::toString)
+                         .map(Object.class::cast)
+                         .toList());
+    } else {
+      return pair;
+    }
+  }
+
+  private StatisticFieldMapping getFieldMapping(Map<String, StatisticFieldMapping> mappedFields, String name) {
+    if (mappedFields.containsKey(name)) {
+      return mappedFields.get(name);
+    } else if (mappedFieldNames.containsKey(name)) {
+      return new StatisticFieldMapping(name, mappedFieldNames.get(name), false);
+    } else {
+      return null;
+    }
+  }
+
+  private String createFieldMapping(String f, Object value) {
+    String type = getFieldMappingType(value);
+    String existingType = mappedFieldNames.putIfAbsent(f, type);
+    if (existingType == null) {
+      try {
+        sendPutRequest(elasticsearchConfiguration.getIndexAlias() + "/_mapping", String.format("""
+            {
+              "properties": {
+                "%s" : {
+                  "type" : "%s"
+                }
+              }
+            }
+            """, f, type));
+        LOG.info("Create ES Mapping for field '{}' with type '{}'", f, type);
+        sendRefreshIndex();
+        listenerService.broadcast(FIELD_MAPPING_CREATED_EVENT, f, type);
+      } catch (Exception e) {
+        if (LOG.isDebugEnabled()) {
+          LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing.",
+                   f,
+                   type,
+                   e);
+        } else {
+          LOG.warn("Error while creating ES Mapping for field '{}' with type '{}'. It may already exists. Continue and consider it as existing. Error: {}",
+                   f,
+                   type,
+                   e.getMessage());
+        }
+      }
+      return type;
+    } else {
+      return existingType;
+    }
+  }
+
+  private boolean checkFieldMapping(Object value, StatisticFieldMapping mapping) { // NOSONAR
     if (mapping == null) {
       return true;
     } else {
@@ -507,15 +643,47 @@ public class ElasticsearchAnalyticsStorage {
       if (StringUtils.equalsIgnoreCase(mappedType, fieldMappingType)) {
         return true;
       } else {
-        return switch (fieldMappingType) {
-        case LONG_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(mappedType) || LONG_MAPPING_TYPE.equals(mappedType);
-        case FLOAT_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(mappedType);
-        case BOOLEAN_MAPPING_TYPE -> BOOLEAN_MAPPING_TYPE.equals(mappedType);
-        case KEYWORD_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(mappedType) || TEXT_MAPPING_TYPE.equals(mappedType);
-        case TEXT_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(mappedType) || TEXT_MAPPING_TYPE.equals(mappedType);
+        return switch (mappedType) {
+        case LONG_MAPPING_TYPE -> LONG_MAPPING_TYPE.equals(fieldMappingType)
+                                  || (KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                      && value instanceof String s
+                                      && isLongValue(s));
+        case FLOAT_MAPPING_TYPE -> FLOAT_MAPPING_TYPE.equals(fieldMappingType)
+                                   || LONG_MAPPING_TYPE.equals(fieldMappingType)
+                                   || (KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                       && value instanceof String s
+                                       && isDecimalValue(s));
+        case BOOLEAN_MAPPING_TYPE -> BOOLEAN_MAPPING_TYPE.equals(fieldMappingType)
+                                     || (KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                         && value instanceof String s
+                                         && isBooleanValue(s));
+        case KEYWORD_MAPPING_TYPE, TEXT_MAPPING_TYPE -> KEYWORD_MAPPING_TYPE.equals(fieldMappingType)
+                                                        || TEXT_MAPPING_TYPE.equals(fieldMappingType);
         default -> false;
         };
       }
+    }
+  }
+
+  private boolean isBooleanValue(String stringValue) {
+    return StringUtils.equalsAnyIgnoreCase(stringValue, "true", "false");
+  }
+
+  private boolean isLongValue(String value) {
+    try {
+      Long.parseLong(value);
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+
+  private boolean isDecimalValue(String value) {
+    try {
+      new BigDecimal(value);
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
     }
   }
 
@@ -529,7 +697,11 @@ public class ElasticsearchAnalyticsStorage {
     case Float v -> FLOAT_MAPPING_TYPE;
     case Double v -> FLOAT_MAPPING_TYPE;
     case Boolean v -> BOOLEAN_MAPPING_TYPE;
-    case Collection v -> getFieldMappingType(v.toArray()[0]);
+    case Collection v -> ((Collection<?>) v).stream()
+                                            .filter(Objects::nonNull)
+                                            .findFirst()
+                                            .map(this::getFieldMappingType)
+                                            .orElse(KEYWORD_MAPPING_TYPE);
     default -> KEYWORD_MAPPING_TYPE;
     };
   }

--- a/analytics-services/src/main/java/io/meeds/analytics/oauth/util/Utils.java
+++ b/analytics-services/src/main/java/io/meeds/analytics/oauth/util/Utils.java
@@ -101,47 +101,47 @@ public class Utils {
   }
 
   public static void addOAuthClientFields(StatisticData statisticData, RegisteredClient client) {
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_ID, getClientId(client));
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
-    statisticData.addParameter(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_ID, getClientId(client));
+    statisticData.addKeyword(PARAM_OAUTH_CLIENT_NAME, client.getClientName());
+    statisticData.addKeywords(PARAM_OAUTH_CLIENT_REDIRECT_URIS, client.getRedirectUris());
     if (CollectionUtils.isNotEmpty(client.getAuthorizationGrantTypes())) {
-      statisticData.addParameter(PARAM_OAUTH_CLIENT_AUTH_METHOD,
-                                 client.getClientAuthenticationMethods()
-                                       .stream()
-                                       .map(ClientAuthenticationMethod::getValue)
-                                       .toList());
+      statisticData.addKeywords(PARAM_OAUTH_CLIENT_AUTH_METHOD,
+                                client.getClientAuthenticationMethods()
+                                      .stream()
+                                      .map(ClientAuthenticationMethod::getValue)
+                                      .toList());
     }
     if (CollectionUtils.isNotEmpty(client.getAuthorizationGrantTypes())) {
-      statisticData.addParameter(PARAM_OAUTH_CLIENT_GRANT_TYPES,
-                                 client.getAuthorizationGrantTypes()
-                                       .stream()
-                                       .map(AuthorizationGrantType::getValue)
-                                       .toList());
+      statisticData.addKeywords(PARAM_OAUTH_CLIENT_GRANT_TYPES,
+                                client.getAuthorizationGrantTypes()
+                                      .stream()
+                                      .map(AuthorizationGrantType::getValue)
+                                      .toList());
     }
     if (CollectionUtils.isNotEmpty(client.getAuthorizationGrantTypes())) {
-      statisticData.addParameter(PARAM_OAUTH_CLIENT_SCOPES,
-                                 client.getScopes()
-                                       .stream()
-                                       .map(s -> PARAM_SCOPE_PREFIX + s)
-                                       .toList());
+      statisticData.addKeywords(PARAM_OAUTH_CLIENT_SCOPES,
+                                client.getScopes()
+                                      .stream()
+                                      .map(s -> PARAM_SCOPE_PREFIX + s)
+                                      .toList());
     }
   }
 
   public static void addOAuthConsentFields(StatisticData statisticData, OAuth2AuthorizationConsent consent) {
-    statisticData.addParameter(PARAM_OAUTH_CONSENT_SCOPES,
-                               consent.getScopes()
-                                      .stream()
-                                      .map(s -> PARAM_SCOPE_PREFIX + s)
-                                      .toList());
+    statisticData.addKeywords(PARAM_OAUTH_CONSENT_SCOPES,
+                              consent.getScopes()
+                                     .stream()
+                                     .map(s -> PARAM_SCOPE_PREFIX + s)
+                                     .toList());
   }
 
   public static void addOAuthTokenFields(StatisticData statisticData, OAuth2Authorization token) {
-    statisticData.addParameter(PARAM_OAUTH_TOKEN_ID, DigestUtils.sha256Hex(token.getId()).substring(0, 16));
-    statisticData.addParameter(PARAM_OAUTH_TOKEN_SCOPES,
-                               token.getAuthorizedScopes()
-                                    .stream()
-                                    .map(s -> PARAM_SCOPE_PREFIX + s)
-                                    .toList());
+    statisticData.addKeyword(PARAM_OAUTH_TOKEN_ID, DigestUtils.sha256Hex(token.getId()).substring(0, 16));
+    statisticData.addKeywords(PARAM_OAUTH_TOKEN_SCOPES,
+                              token.getAuthorizedScopes()
+                                   .stream()
+                                   .map(s -> PARAM_SCOPE_PREFIX + s)
+                                   .toList());
   }
 
   public static String getClientId(RegisteredClient client) {

--- a/analytics-services/src/main/resources/analytics-es-template.json
+++ b/analytics-services/src/main/resources/analytics-es-template.json
@@ -23,10 +23,10 @@
           "format": "epoch_millis"
         },
         "userId": {
-          "type": "long"
+          "type": "keyword"
         },
         "spaceId": {
-          "type": "long"
+          "type": "keyword"
         },
         "module": {
           "type": "keyword"

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AbstractAnalyticsPortlet.java
@@ -20,6 +20,7 @@
 package io.meeds.analytics.portlet;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
 import java.util.*;
 
 import javax.portlet.*;
@@ -272,7 +273,11 @@ public abstract class AbstractAnalyticsPortlet<T> extends GenericPortlet {
 
   protected void addTimeZoneFilter(ResourceRequest request, AbstractAnalyticsFilter filter) {
     String timeZone = request.getParameter("timeZone");
-    filter.setTimeZone(timeZone);
+    if (StringUtils.isBlank(timeZone)) {
+      filter.setTimeZone(ZoneOffset.UTC.getId());
+    } else {
+      filter.setTimeZone(timeZone);
+    }
   }
 
   protected void addLanguageFilter(ResourceRequest request, AnalyticsFilter filter) {

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
@@ -100,7 +100,10 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
       middleOfPeriod = (period.getFromInMS() + period.getToInMS()) / 2;
       filter.setPeriodDateInMS(middleOfPeriod);
       filter.setPeriodType(periodType);
+      filter.setCustomPeriod(null);
     } else {
+      filter.setPeriodType(null);
+      filter.setPeriodDate(null);
       filter.setCustomPeriod(period);
     }
   }

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ProfilePropertyItemAttributeLabel.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ProfilePropertyItemAttributeLabel.vue
@@ -82,7 +82,7 @@ export default {
       return this.property?.split('.')?.[1];
     },
     propertyNameKey() {
-      return this.propertyName?.replace?.('_alt', '');
+      return this.propertyName?.replace?.(/_alt\d*$/, '');
     },
     hasLabel() {
       return this.$te(`analytics.field.label.${this.propertyNameKey}`);

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItem.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItem.vue
@@ -101,7 +101,7 @@ export default {
       return this.chartData.userId || this.chartData.modifierSocialId;
     },
     operationLabel() {
-      const operationLabelI18NValue = `analytics.${this.chartData.operation?.replace?.('_alt', '')}`;
+      const operationLabelI18NValue = `analytics.${this.chartData.operation?.replace?.(/_alt\d*$/, '')}`;
       return this.$te(operationLabelI18NValue) ?
         (this.chartData.operation?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(operationLabelI18NValue)}) : this.$t(operationLabelI18NValue)) // NOSONAR
         : this.chartData.operation;

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItemAttribute.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItemAttribute.vue
@@ -58,13 +58,13 @@ export default {
   },
   computed: {
     keyLabel() {
-      const fieldLabelI18NKey = `analytics.field.label.${this.attrKey?.replace?.('_alt', '')}`;
+      const fieldLabelI18NKey = `analytics.field.label.${this.attrKey?.replace?.(/_alt\d*$/, '')}`;
       return this.$te(fieldLabelI18NKey) ?
         (this.attrKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey)) // NOSONAR
         : this.attrKey;
     },
     valueLabel() {
-      const fieldLabelI18NValue = `analytics.${this.attrValue?.replace?.('_alt', '')}`;
+      const fieldLabelI18NValue = `analytics.${this.attrValue?.replace?.(/_alt\d*$/, '')}`;
       return this.$te(fieldLabelI18NValue) ?
         (this.attrValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NValue)}) : this.$t(fieldLabelI18NValue)) // NOSONAR
         : this.attrValue;
@@ -73,7 +73,7 @@ export default {
       if (this.sampleItemExtensions) {
         return Object.values(this.sampleItemExtensions)
           .sort((ext1, ext2) => (ext1.rank || 0) - (ext2.rank || 0))
-          .find(extension => extension?.match?.(this.attrKey?.replace?.('_alt', ''), this.attrValue)) || null;
+          .find(extension => extension?.match?.(this.attrKey?.replace?.(/_alt\d*$/, ''), this.attrValue)) || null;
       }
       return null;
     },

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/FieldSelection.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/FieldSelection.vue
@@ -116,23 +116,27 @@ export default {
       id: `FieldSelection${parseInt(Math.random() * 10000)
         .toString()
         .toString()}`,
+      selectedFieldMapping: null,
     };
   },
   computed: {
     menuProps() {
       return this.attach && 'maxHeight = 100' || '';
     },
+    filteredFieldsMappings() {
+      return this.selectedFieldMapping ? [this.selectedFieldMapping, ...this.fieldsMappings] : this.fieldsMappings;
+    },
     fieldNames() {
-      this.fieldsMappings.forEach(fieldMapping => {
+      this.filteredFieldsMappings.forEach(fieldMapping => {
         if (!fieldMapping.label) {
           const label = fieldMapping.name;
           const labelPart = label.indexOf('.') >= 0 ? label.substring(label.lastIndexOf('.') + 1) : label;
-          const fieldLabelI18NKey = `analytics.field.label.${labelPart?.replace?.('_alt', '')}`;
+          const fieldLabelI18NKey = `analytics.field.label.${labelPart?.replace?.(/_alt\d*$/, '')}`;
           const fieldLabelI18NValue = labelPart?.includes?.('_alt') && this.$te(fieldLabelI18NKey) ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey);
           fieldMapping.label = fieldLabelI18NValue === fieldLabelI18NKey ? `${this.$t('analytics.field.label.default')} ${label}` : fieldLabelI18NValue;
         }
       });
-      return this.fieldsMappings;
+      return this.filteredFieldsMappings;
     },
     fields() {
       return this.fieldNames.filter(field => (!this.aggregation || field.aggregation) && (!this.numeric || field.numeric || field.date))
@@ -145,8 +149,25 @@ export default {
       // See https://www.reddit.com/r/vuetifyjs/comments/819h8u/how_to_close_a_multiple_autocomplete_vselect/
       this.$refs.fieldSelectAutoComplete.isFocused = false;
     });
+    this.init();
   },
   methods: {
+    init() {
+      if (this.value && !this.fieldNames.includes(this.value)) {
+        this.selectedFieldMapping = {
+          'name': this.value,
+          'searchFieldName': this.value,
+          'aggregationFieldName': `${this.value}.keyword`,
+          'aggregation': this.aggregation,
+          'hasKeywordSubField': this.aggregation,
+          'type': 'keyword',
+          'keyword': this.aggregation,
+          'text': true,
+        };
+      } else {
+        this.selectedFieldMapping = null;
+      }
+    },
     updateData() {
       this.$emit('input', this.value);
       this.$emit('change', this.value);

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/TextValuesFilter.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/TextValuesFilter.vue
@@ -107,7 +107,7 @@ export default {
       if (this.isProfilePropertyOption) {
         return await this.getProfilePropertyOptionTranslation(value);
       }
-      const key = `analytics.${value?.replace?.('_alt', '')}`;
+      const key = `analytics.${value?.replace?.(/_alt\d*$/, '')}`;
       return this.$te(key) ?
         (value?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(key)}) : this.$t(key)) // NOSONAR
         : value;

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
@@ -231,15 +231,15 @@ export default {
       const fieldName = label.split('=')[0];
       const fieldValue = label.split('=')[1];
       if (fieldValue) {
-        const extension = this.$root.fieldNameValueExtensions.find(ext => ext?.match?.(fieldName?.replace?.('_alt', ''), fieldValue));
+        const extension = this.$root.fieldNameValueExtensions.find(ext => ext?.match?.(fieldName?.replace?.(/_alt\d*$/, ''), fieldValue));
         if (extension) {
           return extension.getLabel(fieldName, fieldValue);
         } else {
-          let fieldLabelI18NKey = `analytics.${fieldValue?.replace?.('_alt', '')}`;
+          let fieldLabelI18NKey = `analytics.${fieldValue?.replace?.(/_alt\d*$/, '')}`;
           if (this.$te(fieldLabelI18NKey)) {
             return fieldValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey);
           } else {
-            fieldLabelI18NKey = `analytics.field.label.${fieldValue?.replace?.('_alt', '')}`;
+            fieldLabelI18NKey = `analytics.field.label.${fieldValue?.replace?.(/_alt\d*$/, '')}`;
             return this.$te(fieldLabelI18NKey) ?
               (fieldValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey)) // NOSONAR
               : label;

--- a/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/rate-portlet/components/AnalyticsRateApplication.vue
@@ -331,14 +331,14 @@ export default {
       }
 
       this.loading = true;
+      const isPredefinedPeriod = !!this.selectedPeriod.period;
       const params = {
         lang: eXo.env.portal.language && eXo.env.portal.language.replace('_','-'),
         periodType: this.selectedPeriod.period || '',
-        min: this.selectedPeriod.min,
-        max: this.selectedPeriod.max + 60000,
+        min: isPredefinedPeriod ? this.selectedPeriod.min : this.toLocalDayStartInMS(this.selectedPeriod.min),
+        max: isPredefinedPeriod ? this.selectedPeriod.max + 60000 : this.toLocalDayEndExclusiveInMS(this.selectedPeriod.max),
         timeZone: this.$analyticsUtils.USER_TIMEZONE_ID,
       };
-      params.timeZone = this.$analyticsUtils.USER_TIMEZONE_ID;
       if (this.selectedPeriod.period) {
         params.date = Date.now();
       }
@@ -366,6 +366,14 @@ export default {
           this.error = 'Error getting analytics';
         })
         .finally(() => this.loading = false);
+    },
+    toLocalDayStartInMS(timestamp) {
+      const date = new Date(timestamp);
+      return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()).getTime();
+    },
+    toLocalDayEndExclusiveInMS(timestamp) {
+      const date = new Date(timestamp);
+      return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1).getTime();
     },
     closeMenu(){
       this.showMenu=false;

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetList.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetList.vue
@@ -45,7 +45,7 @@ export default {
   },
   computed: {
     label() {
-      return this.labelKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(this.labelKey?.replace?.('_alt', ''))}) : this.$t(this.labelKey);
+      return this.labelKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(this.labelKey?.replace?.(/_alt\d*$/, ''))}) : this.$t(this.labelKey);
     },
     hasSpaces() {
       return this.list?.length;

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/settings/AnalyticsTableColumnSetting.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/settings/AnalyticsTableColumnSetting.vue
@@ -122,7 +122,7 @@ export default {
   }),
   computed: {
     columnTitle() {
-      return this.column && this.column.title?.replace?.('_alt', '');
+      return this.column && this.column.title?.replace?.(/_alt\d*$/, '');
     },
     canEnableIdentityFields() {
       return this.useUserField || this.useSpaceField;

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -206,7 +206,7 @@ export default {
     },
     addHeader(headers, column, index) {
       headers.push({
-        text: column.title && this.$t(column.title?.replace?.('_alt', '')) || '',
+        text: column.title && this.$t(column.title?.replace?.(/_alt\d*$/, '')) || '',
         align: column.align || 'center',
         sortable: column.sortable,
         value: `column${index}`,

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCell.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCell.vue
@@ -168,7 +168,7 @@ export default {
       if (this.cellValueExtensions) {
         return Object.values(this.cellValueExtensions)
           .sort((ext1, ext2) => (ext1.rank || 0) - (ext2.rank || 0))
-          .find(extension => extension?.match?.(this.columnField?.replace?.('_alt', ''), this.columnAggregationType, this.columnDataType, this.cellItem)) || null;
+          .find(extension => extension?.match?.(this.columnField?.replace?.(/_alt\d*$/, ''), this.columnAggregationType, this.columnDataType, this.cellItem)) || null;
       }
       return null;
     },

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellValue.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellValue.vue
@@ -152,7 +152,7 @@ export default {
   }),
   computed: {
     i18NValue() {
-      const key = `analytics.${this.value?.replace?.('_alt', '')}`;
+      const key = `analytics.${this.value?.replace?.(/_alt\d*$/, '')}`;
       return this.$te(key) ?
         (this.value?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(key)}) : this.$t(key)) // NOSONAR
         : this.value;


### PR DESCRIPTION
Avoid creating *_alt Elasticsearch fields when an incoming typed statistic value is incompatible with an already mapped keyword/text field.

Now that statistic producers use explicit typed APIs, mismatches against an existing mapping are treated as producer-side errors: the value is ignored and logged once instead of mutating the ES schema.

Existing *_alt fields remain supported for backward compatibility. New unmapped fields are still mapped normally.