### PR TITLE
fix: resolve report fields against available mappings - EXO-87755

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/model/ProductOnlyStackTraceException.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/model/ProductOnlyStackTraceException.java
@@ -87,6 +87,9 @@ public class ProductOnlyStackTraceException extends RuntimeException {
   @Override
   public synchronized Throwable getCause() {
     Throwable cause = super.getCause();
+    if (cause == null) {
+      return null;
+    }
     StackTraceElement[] stackTrace = getStackTrace();
     List<StackTraceElement> productStackTrace = Arrays.stream(stackTrace)
                                                       .filter(trace -> StringUtils.containsAny(trace.getClassName(),

--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -26,26 +26,37 @@ import static java.time.temporal.ChronoField.YEAR;
 
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
 import java.time.temporal.IsoFields;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.time.LocalDate;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -71,11 +82,13 @@ import org.exoplatform.ws.frameworks.json.impl.ObjectBuilder;
 import io.meeds.analytics.api.service.StatisticDataQueueService;
 import io.meeds.analytics.model.StatisticData;
 import io.meeds.analytics.model.StatisticData.StatisticStatus;
+import io.meeds.analytics.model.StatisticFieldMapping;
 import io.meeds.social.category.model.Category;
 import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.service.CategoryService;
 
 public class AnalyticsUtils {
+
   private static final Log              LOG                              = ExoLogger.getLogger(AnalyticsUtils.class);
 
   private static ProfilePropertyService profilePropertyService;
@@ -185,6 +198,8 @@ public class AnalyticsUtils {
                                                                                                                       2)
                                                                                                          .toFormatter();
 
+  private static final String           KEYWORD_FIELD_NAME_SUFFIX        = ".keyword";
+
   private AnalyticsUtils() {
   }
 
@@ -237,7 +252,7 @@ public class AnalyticsUtils {
   }
 
   public static final String compueLabel(String chartKey, String chartValue) {
-    String defaultLabel = (chartKey == null ? "" : chartKey.replace(".keyword", "") + "=") + chartValue;
+    String defaultLabel = (chartKey == null ? "" : chartKey.replace(KEYWORD_FIELD_NAME_SUFFIX, "") + "=") + chartValue;
     if (StringUtils.isBlank(chartKey) || StringUtils.isBlank(chartValue) || !COMPUTED_CHART_LABEL.contains(chartKey)) {
       return defaultLabel;
     }
@@ -511,15 +526,24 @@ public class AnalyticsUtils {
     }
   }
 
-  public static void convertToAltFieldName(Supplier<String> supplier, Consumer<String> consumer, Set<String> fieldNames) {
+  public static void convertFieldName(Supplier<String> supplier,
+                                      Consumer<String> consumer,
+                                      Set<StatisticFieldMapping> mappings,
+                                      boolean isAggregation) {
     String fieldName = supplier.get();
-    if (StringUtils.isBlank(fieldName) || fieldNames == null || fieldNames.isEmpty()) {
+    if (StringUtils.isBlank(fieldName) || mappings == null || mappings.isEmpty()) {
       return;
     }
+    String fieldNameConverted = convertKeywordFieldName(consumer, fieldName, mappings, isAggregation);
+    String fieldNameNoKeyword = fieldName.replace(KEYWORD_FIELD_NAME_SUFFIX, "");
     for (int i = MAX_ALTERNATIVE_FIELD_COUNT; i >= 1; i--) {
-      String altFieldName = getAlternativeFieldName(fieldName, i);
-      if (fieldNames.contains(altFieldName)) {
-        consumer.accept(altFieldName);
+      String altFieldName = getAlternativeFieldName(fieldNameNoKeyword, i);
+      if (mappings.stream().anyMatch(f -> f.getName().equals(altFieldName))) {
+        if (fieldNameConverted.contains(KEYWORD_FIELD_NAME_SUFFIX)) {
+          consumer.accept(altFieldName + KEYWORD_FIELD_NAME_SUFFIX);
+        } else {
+          consumer.accept(altFieldName);
+        }
         return;
       }
     }
@@ -533,6 +557,33 @@ public class AnalyticsUtils {
 
   public static String getBaseFieldName(String fieldName) {
     return fieldName == null ? null : fieldName.replaceFirst(ALTERNATIVE_FIELD_SUFFIX + "\\d*$", "");
+  }
+
+  private static String convertKeywordFieldName(Consumer<String> consumer,
+                                                String fieldName,
+                                                Set<StatisticFieldMapping> mappings,
+                                                boolean isAggregation) {
+    boolean isAggregationFieldName = fieldName.contains(KEYWORD_FIELD_NAME_SUFFIX);
+    String fieldNameNoKeyword = fieldName.replace(KEYWORD_FIELD_NAME_SUFFIX, "");
+    StatisticFieldMapping mapping = mappings.stream()
+                                            .filter(f -> f.getName().equals(fieldNameNoKeyword))
+                                            .findFirst()
+                                            .orElse(null);
+    if (mapping != null) {
+      if (isAggregationFieldName
+          && (!isAggregation || !mapping.isHasKeywordSubField() || !StringUtils.equals(mapping.getType(), "text"))) {
+        consumer.accept(fieldNameNoKeyword);
+        return fieldNameNoKeyword;
+      } else if (!isAggregationFieldName
+                 && isAggregation
+                 && mapping.isHasKeywordSubField()
+                 && StringUtils.equals(mapping.getType(), "text")) {
+        String fieldNameWithKeyword = fieldName + KEYWORD_FIELD_NAME_SUFFIX;
+        consumer.accept(fieldNameWithKeyword);
+        return fieldNameWithKeyword;
+      }
+    }
+    return fieldName;
   }
 
   private static int getSize(String[] array) {

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsPortlet.java
@@ -19,11 +19,12 @@
  */
 package io.meeds.analytics.portlet;
 
+import static io.meeds.analytics.utils.AnalyticsUtils.convertFieldName;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.portlet.PortletException;
 import javax.portlet.ResourceRequest;
@@ -41,8 +42,6 @@ import io.meeds.analytics.model.filter.AnalyticsFilter;
 import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
 import io.meeds.analytics.utils.AnalyticsUtils;
-
-import static io.meeds.analytics.utils.AnalyticsUtils.convertToAltFieldName;
 
 public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> {
 
@@ -116,27 +115,27 @@ public class AnalyticsPortlet extends AbstractAnalyticsPortlet<AnalyticsFilter> 
   private AnalyticsFilter getFilter(ResourceRequest request) {
     AnalyticsFilter filter = getFilterFromPreferences(request);
     Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
-    Set<String> fieldNames = mappings.stream()
-                                     .map(StatisticFieldMapping::getName)
-                                     .collect(Collectors.toSet());
 
     if (StringUtils.isNotBlank(filter.getMultipleChartsField())) {
-      convertToAltFieldName(filter::getMultipleChartsField,
-                            filter::setMultipleChartsField,
-                            fieldNames);
+      convertFieldName(filter::getMultipleChartsField,
+                       filter::setMultipleChartsField,
+                       mappings,
+                       true);
     }
     if (CollectionUtils.isNotEmpty(filter.getAggregations())) {
       for (AnalyticsAggregation analyticsAggregation : filter.getAggregations()) {
-        convertToAltFieldName(analyticsAggregation::getField,
-                              analyticsAggregation::setField,
-                              fieldNames);
+        convertFieldName(analyticsAggregation::getField,
+                         analyticsAggregation::setField,
+                         mappings,
+                         true);
       }
     }
     if (CollectionUtils.isNotEmpty(filter.getFilters())) {
       for (AnalyticsFieldFilter analyticsFilter : filter.getFilters()) {
-        convertToAltFieldName(analyticsFilter::getField,
-                              analyticsFilter::setField,
-                              fieldNames);
+        convertFieldName(analyticsFilter::getField,
+                         analyticsFilter::setField,
+                         mappings,
+                         false);
       }
     }
     return filter;

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsQueryPortlet.java
@@ -19,22 +19,19 @@
  */
 package io.meeds.analytics.portlet;
 
+import static io.meeds.analytics.utils.AnalyticsUtils.convertFieldName;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import javax.portlet.PortletException;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
 
-import io.meeds.analytics.model.StatisticFieldMapping;
-import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
-import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
-import io.meeds.analytics.model.filter.search.AnalyticsFieldFilterType;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -46,11 +43,13 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.webui.Utils;
 
 import io.meeds.analytics.api.service.AnalyticsService;
+import io.meeds.analytics.model.StatisticFieldMapping;
 import io.meeds.analytics.model.chart.ChartDataList;
 import io.meeds.analytics.model.filter.AnalyticsFilter;
+import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
+import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
+import io.meeds.analytics.model.filter.search.AnalyticsFieldFilterType;
 import io.meeds.analytics.utils.AnalyticsUtils;
-
-import static io.meeds.analytics.utils.AnalyticsUtils.convertToAltFieldName;
 
 public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
 
@@ -136,19 +135,20 @@ public class AnalyticsQueryPortlet extends GenericDispatchedViewPortlet {
     AnalyticsFilter filter = getFilterFromRequest(request);
     applyParentSpaceFilter(request, filter);
     Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
-    Set<String> fieldNames = mappings.stream().map(StatisticFieldMapping::getName).collect(Collectors.toSet());
     if (CollectionUtils.isNotEmpty(filter.getAggregations())) {
       for (AnalyticsAggregation analyticsAggregation : filter.getAggregations()) {
-        convertToAltFieldName(analyticsAggregation::getField,
-                              analyticsAggregation::setField,
-                              fieldNames);
+        convertFieldName(analyticsAggregation::getField,
+                         analyticsAggregation::setField,
+                         mappings,
+                         true);
       }
     }
     if (CollectionUtils.isNotEmpty(filter.getFilters())) {
       for (AnalyticsFieldFilter analyticsFilter : filter.getFilters()) {
-        convertToAltFieldName(analyticsFilter::getField,
-                              analyticsFilter::setField,
-                              fieldNames);
+        convertFieldName(analyticsFilter::getField,
+                         analyticsFilter::setField,
+                         mappings,
+                         false);
       }
     }
     return filter;

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsRatePortlet.java
@@ -24,9 +24,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import javax.portlet.*;
+import javax.portlet.PortletException;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -34,7 +35,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 
 import io.meeds.analytics.model.StatisticFieldMapping;
-import io.meeds.analytics.model.filter.*;
+import io.meeds.analytics.model.filter.AnalyticsPercentageFilter;
+import io.meeds.analytics.model.filter.AnalyticsPercentageItemFilter;
+import io.meeds.analytics.model.filter.AnalyticsPeriod;
+import io.meeds.analytics.model.filter.AnalyticsPeriodType;
 import io.meeds.analytics.model.filter.aggregation.AnalyticsAggregation;
 import io.meeds.analytics.model.filter.aggregation.AnalyticsPercentageLimit;
 import io.meeds.analytics.model.filter.search.AnalyticsFieldFilter;
@@ -111,37 +115,39 @@ public class AnalyticsRatePortlet extends AbstractAnalyticsPortlet<AnalyticsPerc
   private AnalyticsPercentageFilter getFilter(ResourceRequest request) {
     AnalyticsPercentageFilter filter = getFilterFromPreferences(request);
     Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
-    Set<String> fieldNames = mappings.stream()
-                                     .map(StatisticFieldMapping::getName)
-                                     .collect(Collectors.toSet());
 
-    convertToAltFieldName(filter.getValue(), fieldNames);
-    convertToAltFieldName(filter.getThreshold(), fieldNames);
+    convertToFieldName(filter.getValue(), mappings);
+    convertToFieldName(filter.getThreshold(), mappings);
 
     AnalyticsPercentageLimit percentageLimit = filter.getPercentageLimit();
     if (percentageLimit != null) {
-      AnalyticsUtils.convertToAltFieldName(percentageLimit::getField,
-                                           percentageLimit::setField,
-                                           fieldNames);
-      convertToAltFieldName(percentageLimit.getAggregation(), fieldNames);
+      AnalyticsUtils.convertFieldName(percentageLimit::getField,
+                                      percentageLimit::setField,
+                                      mappings,
+                                      true);
+      convertToFieldName(percentageLimit.getAggregation(),
+                         mappings);
     }
     return filter;
   }
 
-  private void convertToAltFieldName(AnalyticsPercentageItemFilter valueFilter, Set<String> fieldNames) {
+  private void convertToFieldName(AnalyticsPercentageItemFilter valueFilter,
+                                  Set<StatisticFieldMapping> mappings) {
     if (valueFilter != null) {
       AnalyticsAggregation aggregation = valueFilter.getYAxisAggregation();
       if (aggregation != null) {
-        AnalyticsUtils.convertToAltFieldName(aggregation::getField,
-                                             aggregation::setField,
-                                             fieldNames);
+        AnalyticsUtils.convertFieldName(aggregation::getField,
+                                        aggregation::setField,
+                                        mappings,
+                                        true);
       }
       List<AnalyticsFieldFilter> filters = valueFilter.getFilters();
       if (CollectionUtils.isNotEmpty(filters)) {
         for (AnalyticsFieldFilter analyticsFilter : filters) {
-          AnalyticsUtils.convertToAltFieldName(analyticsFilter::getField,
-                                               analyticsFilter::setField,
-                                               fieldNames);
+          AnalyticsUtils.convertFieldName(analyticsFilter::getField,
+                                          analyticsFilter::setField,
+                                          mappings,
+                                          false);
         }
       }
     }

--- a/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsTablePortlet.java
+++ b/analytics-webapps/src/main/java/io/meeds/analytics/portlet/AnalyticsTablePortlet.java
@@ -22,7 +22,6 @@ package io.meeds.analytics.portlet;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.portlet.PortletException;
 import javax.portlet.ResourceRequest;
@@ -168,46 +167,47 @@ public class AnalyticsTablePortlet extends AbstractAnalyticsPortlet<AnalyticsTab
   private AnalyticsTableFilter getFilter(ResourceRequest request) {
     AnalyticsTableFilter filter = getFilterFromPreferences(request);
     Set<StatisticFieldMapping> mappings = getAnalyticsService().retrieveMapping(false);
-    Set<String> fieldNames = mappings.stream()
-                                     .map(StatisticFieldMapping::getName)
-                                     .collect(Collectors.toSet());
     List<AnalyticsTableColumnFilter> columns = filter.getColumns();
     for (AnalyticsTableColumnFilter analyticsTableColumnFilter : columns) {
-      convertToAltFieldName(analyticsTableColumnFilter, fieldNames);
+      convertFieldName(analyticsTableColumnFilter, mappings);
     }
-    convertToAltFieldName(filter.getMainColumn(), fieldNames);
+    convertFieldName(filter.getMainColumn(), mappings);
     return filter;
   }
 
-  private void convertToAltFieldName(AnalyticsTableColumnFilter columnFilter, Set<String> fieldNames) {
+  private void convertFieldName(AnalyticsTableColumnFilter columnFilter, Set<StatisticFieldMapping> mappings) {
     if (columnFilter != null) {
-      AnalyticsUtils.convertToAltFieldName(columnFilter::getUserField,
-                                           columnFilter::setUserField,
-                                           fieldNames);
-      AnalyticsUtils.convertToAltFieldName(columnFilter::getSpaceField,
-                                           columnFilter::setSpaceField,
-                                           fieldNames);
-      convertToAltFieldName(columnFilter.getThresholdAggregation(),
-                            fieldNames);
-      convertToAltFieldName(columnFilter.getValueAggregation(),
-                            fieldNames);
+      AnalyticsUtils.convertFieldName(columnFilter::getUserField,
+                                      columnFilter::setUserField,
+                                      mappings,
+                                      false);
+      AnalyticsUtils.convertFieldName(columnFilter::getSpaceField,
+                                      columnFilter::setSpaceField,
+                                      mappings,
+                                      false);
+      convertFieldName(columnFilter.getThresholdAggregation(),
+                       mappings);
+      convertFieldName(columnFilter.getValueAggregation(),
+                       mappings);
     }
   }
 
-  private void convertToAltFieldName(AnalyticsTableColumnAggregation columnAggregation, Set<String> fieldNames) {
+  private void convertFieldName(AnalyticsTableColumnAggregation columnAggregation, Set<StatisticFieldMapping> mappings) {
     if (columnAggregation != null) {
       AnalyticsAggregation aggregation = columnAggregation.getAggregation();
       if (aggregation != null) {
-        AnalyticsUtils.convertToAltFieldName(aggregation::getField,
-                                             aggregation::setField,
-                                             fieldNames);
+        AnalyticsUtils.convertFieldName(aggregation::getField,
+                                        aggregation::setField,
+                                        mappings,
+                                        true);
       }
       List<AnalyticsFieldFilter> filters = columnAggregation.getFilters();
       if (CollectionUtils.isNotEmpty(filters)) {
         for (AnalyticsFieldFilter analyticsFilter : filters) {
-          AnalyticsUtils.convertToAltFieldName(analyticsFilter::getField,
-                                               analyticsFilter::setField,
-                                               fieldNames);
+          AnalyticsUtils.convertFieldName(analyticsFilter::getField,
+                                          analyticsFilter::setField,
+                                          mappings,
+                                          false);
         }
       }
     }

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ProfilePropertyItemAttributeLabel.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/ProfilePropertyItemAttributeLabel.vue
@@ -82,7 +82,7 @@ export default {
       return this.property?.split('.')?.[1];
     },
     propertyNameKey() {
-      return this.propertyName?.replace?.(/_alt\d*$/, '');
+      return this.propertyName?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '');
     },
     hasLabel() {
       return this.$te(`analytics.field.label.${this.propertyNameKey}`);

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItem.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItem.vue
@@ -101,7 +101,7 @@ export default {
       return this.chartData.userId || this.chartData.modifierSocialId;
     },
     operationLabel() {
-      const operationLabelI18NValue = `analytics.${this.chartData.operation?.replace?.(/_alt\d*$/, '')}`;
+      const operationLabelI18NValue = `analytics.${this.chartData.operation?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
       return this.$te(operationLabelI18NValue) ?
         (this.chartData.operation?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(operationLabelI18NValue)}) : this.$t(operationLabelI18NValue)) // NOSONAR
         : this.chartData.operation;

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItemAttribute.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/samples/SampleItemAttribute.vue
@@ -58,13 +58,13 @@ export default {
   },
   computed: {
     keyLabel() {
-      const fieldLabelI18NKey = `analytics.field.label.${this.attrKey?.replace?.(/_alt\d*$/, '')}`;
+      const fieldLabelI18NKey = `analytics.field.label.${this.attrKey?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
       return this.$te(fieldLabelI18NKey) ?
         (this.attrKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey)) // NOSONAR
         : this.attrKey;
     },
     valueLabel() {
-      const fieldLabelI18NValue = `analytics.${this.attrValue?.replace?.(/_alt\d*$/, '')}`;
+      const fieldLabelI18NValue = `analytics.${this.attrValue?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
       return this.$te(fieldLabelI18NValue) ?
         (this.attrValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NValue)}) : this.$t(fieldLabelI18NValue)) // NOSONAR
         : this.attrValue;
@@ -73,7 +73,7 @@ export default {
       if (this.sampleItemExtensions) {
         return Object.values(this.sampleItemExtensions)
           .sort((ext1, ext2) => (ext1.rank || 0) - (ext2.rank || 0))
-          .find(extension => extension?.match?.(this.attrKey?.replace?.(/_alt\d*$/, ''), this.attrValue)) || null;
+          .find(extension => extension?.match?.(this.attrKey?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', ''), this.attrValue)) || null;
       }
       return null;
     },

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/FieldSelection.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/FieldSelection.vue
@@ -131,7 +131,7 @@ export default {
         if (!fieldMapping.label) {
           const label = fieldMapping.name;
           const labelPart = label.indexOf('.') >= 0 ? label.substring(label.lastIndexOf('.') + 1) : label;
-          const fieldLabelI18NKey = `analytics.field.label.${labelPart?.replace?.(/_alt\d*$/, '')}`;
+          const fieldLabelI18NKey = `analytics.field.label.${labelPart?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
           const fieldLabelI18NValue = labelPart?.includes?.('_alt') && this.$te(fieldLabelI18NKey) ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey);
           fieldMapping.label = fieldLabelI18NValue === fieldLabelI18NKey ? `${this.$t('analytics.field.label.default')} ${label}` : fieldLabelI18NValue;
         }
@@ -157,7 +157,7 @@ export default {
         this.selectedFieldMapping = {
           'name': this.value,
           'searchFieldName': this.value,
-          'aggregationFieldName': `${this.value}.keyword`,
+          'aggregationFieldName': this.value,
           'aggregation': this.aggregation,
           'hasKeywordSubField': this.aggregation,
           'type': 'keyword',

--- a/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/TextValuesFilter.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/common-components/components/settings/form/TextValuesFilter.vue
@@ -107,7 +107,7 @@ export default {
       if (this.isProfilePropertyOption) {
         return await this.getProfilePropertyOptionTranslation(value);
       }
-      const key = `analytics.${value?.replace?.(/_alt\d*$/, '')}`;
+      const key = `analytics.${value?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
       return this.$te(key) ?
         (value?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(key)}) : this.$t(key)) // NOSONAR
         : value;

--- a/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/generic-portlet/components/chart/AnalyticsChart.vue
@@ -231,15 +231,15 @@ export default {
       const fieldName = label.split('=')[0];
       const fieldValue = label.split('=')[1];
       if (fieldValue) {
-        const extension = this.$root.fieldNameValueExtensions.find(ext => ext?.match?.(fieldName?.replace?.(/_alt\d*$/, ''), fieldValue));
+        const extension = this.$root.fieldNameValueExtensions.find(ext => ext?.match?.(fieldName?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', ''), fieldValue));
         if (extension) {
           return extension.getLabel(fieldName, fieldValue);
         } else {
-          let fieldLabelI18NKey = `analytics.${fieldValue?.replace?.(/_alt\d*$/, '')}`;
+          let fieldLabelI18NKey = `analytics.${fieldValue?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
           if (this.$te(fieldLabelI18NKey)) {
             return fieldValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey);
           } else {
-            fieldLabelI18NKey = `analytics.field.label.${fieldValue?.replace?.(/_alt\d*$/, '')}`;
+            fieldLabelI18NKey = `analytics.field.label.${fieldValue?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
             return this.$te(fieldLabelI18NKey) ?
               (fieldValue?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(fieldLabelI18NKey)}) : this.$t(fieldLabelI18NKey)) // NOSONAR
               : label;

--- a/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetList.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/spaces-list-widget/components/SpacesListWidgetList.vue
@@ -45,7 +45,7 @@ export default {
   },
   computed: {
     label() {
-      return this.labelKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(this.labelKey?.replace?.(/_alt\d*$/, ''))}) : this.$t(this.labelKey);
+      return this.labelKey?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(this.labelKey?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', ''))}) : this.$t(this.labelKey);
     },
     hasSpaces() {
       return this.list?.length;

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/settings/AnalyticsTableColumnSetting.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/settings/AnalyticsTableColumnSetting.vue
@@ -122,7 +122,7 @@ export default {
   }),
   computed: {
     columnTitle() {
-      return this.column && this.column.title?.replace?.(/_alt\d*$/, '');
+      return this.column && this.column.title?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '');
     },
     canEnableIdentityFields() {
       return this.useUserField || this.useSpaceField;

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTable.vue
@@ -206,7 +206,7 @@ export default {
     },
     addHeader(headers, column, index) {
       headers.push({
-        text: column.title && this.$t(column.title?.replace?.(/_alt\d*$/, '')) || '',
+        text: column.title && this.$t(column.title?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')) || '',
         align: column.align || 'center',
         sortable: column.sortable,
         value: `column${index}`,

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCell.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCell.vue
@@ -168,7 +168,7 @@ export default {
       if (this.cellValueExtensions) {
         return Object.values(this.cellValueExtensions)
           .sort((ext1, ext2) => (ext1.rank || 0) - (ext2.rank || 0))
-          .find(extension => extension?.match?.(this.columnField?.replace?.(/_alt\d*$/, ''), this.columnAggregationType, this.columnDataType, this.cellItem)) || null;
+          .find(extension => extension?.match?.(this.columnField?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', ''), this.columnAggregationType, this.columnDataType, this.cellItem)) || null;
       }
       return null;
     },

--- a/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellValue.vue
+++ b/analytics-webapps/src/main/webapp/vue-app/table-portlet/components/table/AnalyticsTableCellValue.vue
@@ -152,7 +152,7 @@ export default {
   }),
   computed: {
     i18NValue() {
-      const key = `analytics.${this.value?.replace?.(/_alt\d*$/, '')}`;
+      const key = `analytics.${this.value?.replace?.(/_alt\d*$/, '')?.replace?.('.keyword', '')}`;
       return this.$te(key) ?
         (this.value?.includes?.('_alt') ? this.$t('analytics.field.alternative', {0: this.$t(key)}) : this.$t(key)) // NOSONAR
         : this.value;


### PR DESCRIPTION
Update analytics report filters to resolve configured fields against the current Elasticsearch mappings before executing queries. This handles fields that were remapped to alternative physical names such as *_alt, *_alt2 or *_alt3, and preserves keyword aggregation suffixes only when the mapped field supports them. Also avoid forcing on manually configured keyword fields so product content analytics reports can load data correctly instead of returning empty results.