### PR TITLE
fix: resolve keyword aggregation suffix from the alternative field mapping - EXO-88413

### DIFF
--- a/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
+++ b/analytics-api/src/main/java/io/meeds/analytics/utils/AnalyticsUtils.java
@@ -534,19 +534,17 @@ public class AnalyticsUtils {
     if (StringUtils.isBlank(fieldName) || mappings == null || mappings.isEmpty()) {
       return;
     }
-    String fieldNameConverted = convertKeywordFieldName(consumer, fieldName, mappings, isAggregation);
     String fieldNameNoKeyword = fieldName.replace(KEYWORD_FIELD_NAME_SUFFIX, "");
     for (int i = MAX_ALTERNATIVE_FIELD_COUNT; i >= 1; i--) {
       String altFieldName = getAlternativeFieldName(fieldNameNoKeyword, i);
-      if (mappings.stream().anyMatch(f -> f.getName().equals(altFieldName))) {
-        if (fieldNameConverted.contains(KEYWORD_FIELD_NAME_SUFFIX)) {
-          consumer.accept(altFieldName + KEYWORD_FIELD_NAME_SUFFIX);
-        } else {
-          consumer.accept(altFieldName);
-        }
+      // Check if there is an alternative field mapping
+      if (convertKeywordFieldName(consumer, altFieldName, mappings, isAggregation)) {
         return;
       }
     }
+    // Finally, if no alternative mapping, apply the modification on the
+    // principal field Mapping instead of alternative
+    convertKeywordFieldName(consumer, fieldName, mappings, isAggregation);
   }
 
   public static String getAlternativeFieldName(String fieldName, int alternativeIndex) {
@@ -559,31 +557,24 @@ public class AnalyticsUtils {
     return fieldName == null ? null : fieldName.replaceFirst(ALTERNATIVE_FIELD_SUFFIX + "\\d*$", "");
   }
 
-  private static String convertKeywordFieldName(Consumer<String> consumer,
-                                                String fieldName,
-                                                Set<StatisticFieldMapping> mappings,
-                                                boolean isAggregation) {
-    boolean isAggregationFieldName = fieldName.contains(KEYWORD_FIELD_NAME_SUFFIX);
+  private static boolean convertKeywordFieldName(Consumer<String> consumer,
+                                                 String fieldName,
+                                                 Set<StatisticFieldMapping> mappings,
+                                                 boolean isAggregation) {
     String fieldNameNoKeyword = fieldName.replace(KEYWORD_FIELD_NAME_SUFFIX, "");
     StatisticFieldMapping mapping = mappings.stream()
                                             .filter(f -> f.getName().equals(fieldNameNoKeyword))
                                             .findFirst()
                                             .orElse(null);
-    if (mapping != null) {
-      if (isAggregationFieldName
-          && (!isAggregation || !mapping.isHasKeywordSubField() || !StringUtils.equals(mapping.getType(), "text"))) {
-        consumer.accept(fieldNameNoKeyword);
-        return fieldNameNoKeyword;
-      } else if (!isAggregationFieldName
-                 && isAggregation
-                 && mapping.isHasKeywordSubField()
-                 && StringUtils.equals(mapping.getType(), "text")) {
-        String fieldNameWithKeyword = fieldName + KEYWORD_FIELD_NAME_SUFFIX;
-        consumer.accept(fieldNameWithKeyword);
-        return fieldNameWithKeyword;
-      }
+    if (mapping == null) {
+      return false;
     }
-    return fieldName;
+    if (isAggregation && mapping.isHasKeywordSubField() && StringUtils.equals(mapping.getType(), "text")) {
+      consumer.accept(fieldNameNoKeyword + KEYWORD_FIELD_NAME_SUFFIX);
+    } else {
+      consumer.accept(fieldNameNoKeyword);
+    }
+    return true;
   }
 
   private static int getSize(String[] array) {


### PR DESCRIPTION
Resolve the `.keyword` aggregation suffix from the alternative field's own mapping instead of the base field.
resolve report fields to existing alternative ES mappings
